### PR TITLE
Initial support for controlling device groups

### DIFF
--- a/songpal/group.py
+++ b/songpal/group.py
@@ -97,7 +97,7 @@ class GroupControl:
 
         """
         Available actions
-        
+
         INFO:songpal.upnpctl:Action: <UpnpService.Action(X_GetDeviceInfo)> ([])
         INFO:songpal.upnpctl:Action: <UpnpService.Action(X_GetState)> ([])
         INFO:songpal.upnpctl:Action: <UpnpService.Action(X_GetStateM)> ([])

--- a/songpal/group.py
+++ b/songpal/group.py
@@ -1,0 +1,195 @@
+import attr
+import logging
+
+from async_upnp_client.aiohttp import AiohttpRequester
+from async_upnp_client import UpnpFactory
+
+_LOGGER = logging.getLogger(__name__)
+
+
+from .containers import make
+
+@attr.s
+class GroupState:
+    make = classmethod(make)
+
+    """{'Discoverable': 'NO',
+         'GroupMode': 'IDLE',
+         'GroupName': '',
+         'GroupSong': 'PUBLIC',
+         'GroupState': 'IDLE',
+         'MasterSessionID': 0,
+         'MasterUUID': '',
+         'NumberOfSlaves': 0,
+         'PlayingState': 'STOPPED',
+         'PowerState': 'ON',
+         'RSSIValue': -46,
+         'SessionID': 0,
+         'SlaveList': '',
+         'SlaveNetworkState': '',
+         'WiredLinkSpeed': 0,
+         'WiredState': 'DOWN',
+         'WirelessLinkSpeed': 65,
+         'WirelessState': 'UP',
+         'WirelessType': '802.11bgn'}
+    """
+
+    Discoverable = attr.ib()
+    GroupMode = attr.ib()
+    GroupName = attr.ib()
+    GroupSong = attr.ib()
+    GroupState = attr.ib()
+    MasterSessionID = attr.ib()
+    MasterUUID = attr.ib()
+    NumberOfSlaves = attr.ib()
+    PlayingState = attr.ib()
+    PowerState = attr.ib()
+    RSSIValue = attr.ib()
+    SessionID = attr.ib()
+    SlaveList = attr.ib()
+    SlaveNetworkState = attr.ib()
+    WiredLinkSpeed = attr.ib()
+    WiredState = attr.ib()
+    WirelessLinkSpeed = attr.ib()
+    WirelessState = attr.ib()
+    WirelessType = attr.ib()
+
+    # For GetStateM
+    GroupMemoryCount = attr.ib(default=None)
+    GroupMemoryUpdateID = attr.ib(default=None)
+
+    def __str__(self):
+        s = "Power: %s" % self.PowerState
+        s += "\nMode: %s" % self.GroupMode
+        if self.GroupMode == "GROUP":
+            s += "\nSession ID: %s" % self.SessionID
+            s += "\nGroup: %s" % self.GroupName
+            s += "\nState: %s" % self.GroupState
+            s += "\nSlaves: %s" % self.NumberOfSlaves
+            s += "\n  %s" % self.SlaveList
+
+        if self.WiredState != "DOWN":
+            s += "\nConnection: Wired"
+        if self.WirelessState != "DOWN":
+            s += "\nConnection: %s" % self.WirelessType
+
+        return s
+
+
+class GroupControl:
+    def __init__(self, url):
+        self.url = url
+
+    async def connect(self):
+        requester = AiohttpRequester()
+        factory = UpnpFactory(requester)
+        device = await factory.async_create_device(self.url)
+
+        self.service = device.service('urn:schemas-sony-com:service:Group:1')
+        if not self.service:
+            _LOGGER.error("Unable to find group service!")
+            return False
+
+        for act in self.service.actions.values():
+            _LOGGER.debug("Action: %s (%s)", act, [arg.name for arg in act.in_arguments()])
+
+        return True
+
+        """
+        Available actions
+        
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_GetDeviceInfo)> ([])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_GetState)> ([])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_GetStateM)> ([])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_SetGroupName)> (['GroupName'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_ChangeGroupVolume)> (['GroupVolume'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_GetAllGroupMemory)> ([])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_DeleteGroupMemory)> (['MemoryID'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_UpdateGroupMemory)> (['MemoryID', 'GroupMode', 'GroupName', 'SlaveList', 'CodecType', 'CodecBitrate'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_Start)> (['GroupMode', 'GroupName', 'SlaveList', 'CodecType', 'CodecBitrate'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_Entry)> (['MasterSessionID', 'SlaveList'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_EntryM)> (['MasterSessionID', 'SlaveList'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_Leave)> (['MasterSessionID', 'SlaveList'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_LeaveM)> (['MasterSessionID', 'SlaveList'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_Abort)> (['MasterSessionID'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_SetGroupMute)> (['GroupMute'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_SetCodec)> (['CodecType', 'CodecBitrate'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_GetCodec)> ([])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_Invite)> (['GroupMode', 'GroupName', 'MasterUUID', 'MasterSessionID'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_Exit)> (['SlaveSessionID'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_Play)> (['MasterSessionID'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_Stop)> (['MasterSessionID'])
+        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_Delegate)> (['GroupMode', 'SlaveList', 'DelegateURI', 'DelegateURIMetaData'])
+
+        """
+    async def call(self, action, **kwargs):
+        """Make an action call with given kwargs."""
+        act = self.service.action(action)
+        _LOGGER.info("Calling %s with %s", action, kwargs)
+        res = await act.async_call(**kwargs)
+
+        _LOGGER.info("  Result: %s" % res)
+
+        return res
+
+
+    async def info(self):
+        """Return device info."""
+        """
+        {'MasterCapability': 9, 'TransportPort': 3975}
+        """
+        act = self.service.action("X_GetDeviceInfo")
+        res = await act.async_call()
+        return res
+
+    async def state(self) -> GroupState:
+        """Return the current group state"""
+        act = self.service.action("X_GetState")
+        res = await act.async_call()
+        return GroupState.make(**res)
+
+    async def statem(self):
+        """Return the current group state (memory?)."""
+        act = self.service.action("X_GetStateM")
+        res = await act.async_call()
+        return GroupState.make(**res)
+
+    async def get_group_memory(self, result):
+        """Return group memory."""
+        # Returns an XML with groupMemoryList
+        # X_DeleteGroupMemory)> (['MemoryID'])
+        # X_UpdateGroupMemory)> (['MemoryID', 'GroupMode', 'GroupName', 'SlaveList', 'CodecType', 'CodecBitrate'])
+        act = self.service.action("X_GetAllGroupMemory")
+        res = await act.async_call()
+        return res
+
+    async def abort(self):
+        """Abort current group session."""
+        state = await self.state()
+        res = await self.call("X_Abort", MasterSessionID=state.SessionID)
+        return res
+
+    async def create(self, name, slaves):
+        """Create a group."""
+        # NOTE: codectype and codecbitrate were simply chosen from an example..
+        res = await self.call("X_Start", GroupMode="GROUP",
+                              GroupName=name,
+                              SlaveList=",".join(slaves),
+                              CodecType=0x0040,
+                              CodecBitrate=0x0003)
+        return res
+
+    async def set_mute(self, activate):
+        """Set group mute."""
+        res = await self.call("X_SetGroupMute", GroupMute=activate)
+        return res
+
+    async def set_group_volume(self, volume):
+        """Set group volume."""
+        res = await self.call("X_ChangeGroupVolume", GroupVolume=volume)
+        return res
+
+    async def set_group_name(self, name):
+        """Set group name."""
+        res = await self.call("X_SetGroupName", GroupName=name)
+        return res

--- a/songpal/main.py
+++ b/songpal/main.py
@@ -14,6 +14,7 @@ from songpal.common import ProtocolType
 from songpal.containers import Setting
 from songpal.discovery import Discover
 from songpal.notification import VolumeChange, PowerChange, ContentChange
+from songpal.group import GroupControl
 
 
 def err(msg):
@@ -89,7 +90,6 @@ def print_settings(settings, depth=0):
 
 
 pass_dev = click.make_pass_decorator(Device)
-
 
 @click.group(invoke_without_command=False)
 @click.option("--endpoint", envvar="SONGPAL_ENDPOINT", required=False)
@@ -188,9 +188,7 @@ async def discover(ctx):
             click.echo("    - Service: %s" % serv)
 
     click.echo("Discovering for %s seconds" % TIMEOUT)
-
     await Discover.discover(TIMEOUT, ctx.obj["debug"] or 0, callback=print_discovered)
-
 
 
 @cli.command()
@@ -590,6 +588,52 @@ async def dump_devinfo(dev: Device, file):
         json.dump(res, file, sort_keys=True, indent=4)
     else:
         click.echo(json.dumps(res, sort_keys=True, indent=4))
+
+
+pass_groupctl = click.make_pass_decorator(GroupControl)
+
+@cli.group()
+@click.pass_context
+@coro
+async def group(ctx):
+    url = "http://192.168.250.241:52323/dmr.xml"
+    gc = GroupControl(url)
+    connect = await gc.connect()
+    ctx.obj = gc
+
+@group.command()
+@pass_groupctl
+@coro
+async def info(gc: GroupControl):
+    """Control information."""
+    click.echo(await gc.info())
+
+@group.command()
+@pass_groupctl
+@coro
+async def state(gc: GroupControl):
+    """Current group state."""
+    state = await gc.state()
+    click.echo(state)
+    click.echo("Full state info: %s" % repr(state))
+
+@group.command()
+@pass_groupctl
+@coro
+async def abort(gc: GroupControl):
+    """Abort existing group."""
+    click.echo("Aborting current group..")
+    click.echo(await gc.abort())
+
+@group.command()
+@click.argument('name')
+@click.argument('slaves', nargs=-1, required=True)
+@pass_groupctl
+@coro
+async def create(gc: GroupControl, name, slaves):
+    """Create new group"""
+    click.echo("Creating group %s with slaves: %s" % (name, slaves))
+    click.echo(await gc.create(name, slaves))
 
 
 if __name__ == "__main__":

--- a/songpal/main.py
+++ b/songpal/main.py
@@ -169,6 +169,7 @@ async def status(dev: Device):
 @click.pass_context
 async def discover(ctx):
     """Discover supported devices."""
+<<<<<<< HEAD
     TIMEOUT = 5
 
     async def print_discovered(dev):
@@ -592,14 +593,16 @@ async def dump_devinfo(dev: Device, file):
 
 pass_groupctl = click.make_pass_decorator(GroupControl)
 
+
 @cli.group()
 @click.pass_context
+@click.option('--url', required=True)
 @coro
-async def group(ctx):
-    url = "http://192.168.250.241:52323/dmr.xml"
+async def group(ctx, url):
     gc = GroupControl(url)
     connect = await gc.connect()
     ctx.obj = gc
+
 
 @group.command()
 @pass_groupctl
@@ -607,6 +610,7 @@ async def group(ctx):
 async def info(gc: GroupControl):
     """Control information."""
     click.echo(await gc.info())
+
 
 @group.command()
 @pass_groupctl
@@ -617,6 +621,7 @@ async def state(gc: GroupControl):
     click.echo(state)
     click.echo("Full state info: %s" % repr(state))
 
+
 @group.command()
 @pass_groupctl
 @coro
@@ -624,6 +629,7 @@ async def abort(gc: GroupControl):
     """Abort existing group."""
     click.echo("Aborting current group..")
     click.echo(await gc.abort())
+
 
 @group.command()
 @click.argument('name')

--- a/songpal/main.py
+++ b/songpal/main.py
@@ -624,10 +624,19 @@ async def state(gc: GroupControl):
 @group.command()
 @pass_groupctl
 @coro
-async def abort(gc: GroupControl):
-    """Abort existing group."""
-    click.echo("Aborting current group..")
-    click.echo(await gc.abort())
+async def codec(gc: GroupControl):
+    """Codec settings."""
+    codec = await gc.get_codec()
+    click.echo("Codec: %s" % codec)
+
+
+@group.command()
+@pass_groupctl
+@coro
+async def memory(gc: GroupControl):
+    """Group memory."""
+    mem = await gc.get_group_memory()
+    click.echo("Memory: %s" % mem)
 
 
 @group.command()
@@ -639,6 +648,65 @@ async def create(gc: GroupControl, name, slaves):
     """Create new group"""
     click.echo("Creating group %s with slaves: %s" % (name, slaves))
     click.echo(await gc.create(name, slaves))
+
+
+@group.command()
+@pass_groupctl
+@coro
+async def abort(gc: GroupControl):
+    """Abort existing group."""
+    click.echo("Aborting current group..")
+    click.echo(await gc.abort())
+
+@group.command()
+@pass_groupctl
+@click.argument('slaves', nargs=-1, required=True)
+@coro
+async def add(gc: GroupControl, slaves):
+    """Add speakers to group."""
+    click.echo("Adding to existing group: %s" % slaves)
+    click.echo(await gc.add(slaves))
+
+
+@group.command()
+@pass_groupctl
+@click.argument('slaves', nargs=-1, required=True)
+async def remove(gc: GroupControl, slaves):
+    """Remove speakers from group."""
+    click.echo("Removing from existing group: %s" % slaves)
+    click.echo(await gc.remove(slaves))
+
+
+@group.command()
+@pass_groupctl
+@click.argument('volume', type=int)
+async def volume(gc: GroupControl, volume):
+    """Adjust volume [-100, 100]"""
+    click.echo("Setting volume to %s" % volume)
+    click.echo(await gc.set_group_volume(volume))
+
+
+@group.command()
+@pass_groupctl
+@click.argument('mute', type=bool)
+async def mute(gc: GroupControl, mute):
+    """(Un)mute group."""
+    click.echo("Muting group: %s" % mute)
+    click.echo(await gc.set_mute(mute))
+
+
+@group.command()
+@pass_groupctl
+async def play(gc: GroupControl):
+    """Play?"""
+    click.echo("Sending play command: %s" % await gc.play())
+
+
+@group.command()
+@pass_groupctl
+async def stop(gc: GroupControl):
+    """Stop playing?"""
+    click.echo("Sending stop command: %s" % await gc.stop())
 
 
 if __name__ == "__main__":

--- a/songpal/main.py
+++ b/songpal/main.py
@@ -169,7 +169,6 @@ async def status(dev: Device):
 @click.pass_context
 async def discover(ctx):
     """Discover supported devices."""
-<<<<<<< HEAD
     TIMEOUT = 5
 
     async def print_discovered(dev):


### PR DESCRIPTION
This PR implements most of the speaker grouping commands.
Most of these are completely untested as I have only a single device, so feedback is appreciated!
Fixes #12 and #32.

```
songpal group --url http://xxxxx:52323/dmr.xml --help
Usage: songpal group [OPTIONS] COMMAND [ARGS]...

Options:
  --url TEXT  [required]
  --help      Show this message and exit.

Commands:
  abort   Abort existing group.
  add     Add speakers to group.
  codec   Codec settings.
  create  Create new group
  info    Control information.
  memory  Group memory.
  mute    (Un)mute group.
  play    Play?
  remove  Remove speakers from group.
  state   Current group state.
  stop    Stop playing?
  volume  Adjust volume [-100, 100].
```

Use `songpal discover` to find the URL and the uuids required for group creation:
```
Found HT-XT3 - BAR-2015
* API version: 1.0
* Endpoint: http://xxxx:10000/sony
* UDN: uuid:00000000-0000-1010-8000-xxxxx
* UPnP URL: http://xxxx:52323/dmr.xml
* Services:
  - Service: guide
  - Service: system
  - Service: audio
  - Service: avContent
```

The "UPnP URL" needs to be passed to group command with `--url`. The uuids printed out with UDN are required for pairing the slave devices.

To test:
```
songpal group --url http://xxx/dmr.xml state
```
should return the current state.

To form a group:
```
songpal group --url <upnp url> create <name of the group> <list of uuids..>
```
E.g.
```
songpal group --url http://xxx/dmr.xml create 'test group' uuid:00000000-0000-1010-8000-xx uuid:00000000-0000-1010-8000-yy uuid:00000000-0000-1010-8000-zz
```
would create a group 'test group' and adding those three devices to it. The URL is the UPnP URL of the master device.

To 'abort' a group:
```
songpal group abort
```

The following commands are not yet exposed and/or implemented:
```
        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_GetStateM)> ([])
        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_SetGroupName)> (['GroupName'])
        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_DeleteGroupMemory)> (['MemoryID'])
        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_UpdateGroupMemory)> (['MemoryID', 'GroupMode', 'GroupName', 'SlaveList', 'CodecType', 'CodecBitrate'])
        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_EntryM)> (['MasterSessionID', 'SlaveList'])
        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_LeaveM)> (['MasterSessionID', 'SlaveList'])
        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_SetCodec)> (['CodecType', 'CodecBitrate'])
        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_Invite)> (['GroupMode', 'GroupName', 'MasterUUID', 'MasterSessionID'])
        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_Exit)> (['SlaveSessionID'])
        INFO:songpal.upnpctl:Action: <UpnpService.Action(X_Delegate)> (['GroupMode', 'SlaveList', 'DelegateURI', 'DelegateURIMetaData'])
```