### PR TITLE
Disable JSON content-type validation

### DIFF
--- a/songpal/device.py
+++ b/songpal/device.py
@@ -98,10 +98,10 @@ class Device:
             if res.status != 200:
                 raise SongpalException(
                     "Got a non-ok (status %s) response for %s" % (res.status, method),
-                    error=await res.json()["error"],
+                    error=await res.json(content_type=None)["error"],
                 )
 
-            res = await res.json()
+            res = await res.json(content_type=None)
 
         # TODO handle exceptions from POST? This used to raise SongpalException
         #      on requests.RequestException (Unable to get APIs).

--- a/songpal/service.py
+++ b/songpal/service.py
@@ -56,7 +56,7 @@ class Service:
                     return res
             else:
                 res = await session.post(endpoint, json=req)
-                json = await res.json()
+                json = await res.json(content_type=None)
 
                 return json
 
@@ -198,7 +198,7 @@ class Service:
                     return res
             else:
                 res = await session.post(self.endpoint, json=req)
-                return await res.json()
+                return await res.json(content_type=None)
 
     def wrap_notification(self, data):
         """Convert notification JSON to a notification class."""


### PR DESCRIPTION
A regression from converting from requests to aiohttp, which requires JSON mandated content-type.
HT-ZF9 is not sending the mandatory content-type header for its guide endpoint,
causing it to fail to ContentTypeError. As we do not really care about the correctness,
this commit disables the content type checking as described in https://docs.aiohttp.org/en/stable/client_advanced.html#disabling-content-type-validation-for-json-responses

Fixes #58