### PR TITLE
Allow forcing getSupportedApiInfo response from local devinfo file

### DIFF
--- a/songpal/main.py
+++ b/songpal/main.py
@@ -110,10 +110,11 @@ pass_dev = click.make_pass_decorator(Device)
 @click.option("-d", "--debug", default=False, count=True)
 @click.option("--post", is_flag=True, required=False)
 @click.option("--websocket", is_flag=True, required=False)
+@click.option("--devinfo-file", type=click.File("r"), required=False)
 @click.pass_context
 @click.version_option()
 @coro
-async def cli(ctx, endpoint, debug, websocket, post):
+async def cli(ctx, endpoint, debug, websocket, post, devinfo_file):
     """Songpal CLI."""
     lvl = logging.INFO
     if debug:
@@ -139,7 +140,9 @@ async def cli(ctx, endpoint, debug, websocket, post):
         protocol = ProtocolType.XHRPost
 
     logging.debug("Using endpoint %s", endpoint)
-    x = Device(endpoint, force_protocol=protocol, debug=debug)
+    x = Device(
+        endpoint, force_protocol=protocol, debug=debug, devinfo_file=devinfo_file
+    )
     try:
         await x.get_supported_methods()
     except SongpalException as ex:

--- a/songpal/service.py
+++ b/songpal/service.py
@@ -73,7 +73,7 @@ class Service:
 
         protocols = payload["protocols"]
         _LOGGER.debug("Available protocols for %s: %s", service_name, protocols)
-        if force_protocol and force_protocol.value in protocols:
+        if force_protocol:
             protocol = force_protocol
         elif "websocket:jsonizer" in protocols:
             protocol = ProtocolType.WebSocket


### PR DESCRIPTION
Some devices do not support the ability to obtain information about available APIs.
This PR adds new --devinfo-file option that allows using an existing devinfo file to feed the list of available services,
which may be helpful for such devices as long as they implement getMethodTypes() call for the services.

Note, if the devinfo file is not listing the protocols, you have to also specify `--post` or `--websocket` in order to make this work.

Potential fix for #29