### PR TITLE
Catch exceptions on device description file fetch

### DIFF
--- a/songpal/discovery.py
+++ b/songpal/discovery.py
@@ -34,7 +34,15 @@ class Discover:
             factory = UpnpFactory(requester)
 
             url = device["location"]
-            device = await factory.async_create_device(url)
+            try:
+                device = await factory.async_create_device(url)
+            except Exception as ex:
+                _LOGGER.error(
+                    "Unable to download the device description file from %s: %s",
+                    url,
+                    ex,
+                )
+                return
 
             if debug > 0:
                 print(etree.ElementTree.tostring(device.xml).decode())

--- a/songpal/discovery.py
+++ b/songpal/discovery.py
@@ -2,6 +2,8 @@ import logging
 from xml import etree
 
 import attr
+from async_upnp_client import UpnpFactory
+from async_upnp_client.aiohttp import AiohttpRequester
 from async_upnp_client.search import async_search
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,9 +27,6 @@ class Discover:
         """Discover supported devices."""
         ST = "urn:schemas-sony-com:service:ScalarWebAPI:1"
         _LOGGER.info("Discovering for %s seconds" % timeout)
-
-        from async_upnp_client import UpnpFactory
-        from async_upnp_client.aiohttp import AiohttpRequester
 
         async def parse_device(device):
             requester = AiohttpRequester()


### PR DESCRIPTION
We catch the base exception as we don't really care what type of exception we get from the fetch. Fixes #92