### PR TITLE
Fix the default value for the notification fallback callback

### DIFF
--- a/songpal/device.py
+++ b/songpal/device.py
@@ -464,7 +464,11 @@ class Device:
         tasks = []
 
         async def handle_notification(notification: ChangeNotification) -> None:
-            callbacks = self.callbacks.get(type(notification), [fallback_callback])
+            fallback_callback_set = (
+                {fallback_callback} if fallback_callback is not None else set()
+            )
+
+            callbacks = self.callbacks.get(type(notification), fallback_callback_set)
             if not callbacks:
                 _LOGGER.debug("No callbacks defined for %s", notification)
                 return


### PR DESCRIPTION
After #112 the `None` value is no longer a valid fallback_callback
value. Instead of allowing it, provide a default no-op callback that
does nothing and use that as default.

This was surfacing as https://github.com/home-assistant/core/issues/77730.