### PR TITLE
Partial support for STR-AN1000

### DIFF
--- a/songpal/containers.py
+++ b/songpal/containers.py
@@ -111,6 +111,7 @@ class Content:
     isBrowsable = attr.ib()
     uri = attr.ib()
     contentKind = attr.ib()
+    kind = attr.ib()  # for newer devices
 
     isPlayable = attr.ib()
     index = attr.ib()
@@ -126,7 +127,8 @@ class Content:
     broadcastFreq = attr.ib()
 
     def __str__(self):
-        return f"{self.title} ({self.uri}, kind: {self.contentKind})"
+        contentKind = self.contentKind if self.contentKind is not None else self.kind
+        return f"{self.title} ({self.uri}, kind: {contentKind})"
 
 
 @attr.s
@@ -172,6 +174,7 @@ class PlayInfo:
 
     stateInfo = attr.ib(converter=_make)
     contentKind = attr.ib()
+    kind = attr.ib()  # for newer devices
     uri = attr.ib()
     output = attr.ib()
 

--- a/songpal/device.py
+++ b/songpal/device.py
@@ -366,9 +366,11 @@ class Device:
         params = {"settings": [{"target": target, "value": value}]}
         return await self.services["avContent"]["setBluetoothSettings"](params)
 
-    async def get_custom_eq(self):
+    async def get_custom_eq(self, target=""):
         """Get custom EQ settings."""
-        return await self.services["audio"]["getCustomEqualizerSettings"]({})
+        return await self.services["audio"]["getCustomEqualizerSettings"](
+            {"target": target}
+        )
 
     async def set_custom_eq(self, target: str, value: str) -> None:
         """Set custom EQ settings."""
@@ -471,9 +473,11 @@ class Device:
         params = {"settings": [{"target": target, "value": value}]}
         return await self.services["audio"]["setSoundSettings"](params)
 
-    async def get_speaker_settings(self) -> List[Setting]:
+    async def get_speaker_settings(self, target="") -> List[Setting]:
         """Return speaker settings."""
-        speaker_settings = await self.services["audio"]["getSpeakerSettings"]({})
+        speaker_settings = await self.services["audio"]["getSpeakerSettings"](
+            {"target": target}
+        )
         return [Setting.make(**x) for x in speaker_settings]
 
     async def set_speaker_settings(self, target: str, value: str):

--- a/songpal/notification.py
+++ b/songpal/notification.py
@@ -155,7 +155,11 @@ class ContentChange(ChangeNotification, PlayInfo):
     @property
     def is_input(self):
         """Return if the change was related to input."""
-        return self.contentKind == "input"
+        return (
+            self.contentKind == "input"
+            if self.contentKind is not None
+            else self.kind == "input"
+        )
 
 
 @attr.s

--- a/songpal/service.py
+++ b/songpal/service.py
@@ -103,13 +103,16 @@ class Service:
 
         for sig in sigs["results"]:
             name = sig[0]
+            version = sig[3]
             parsed_sig = MethodSignature.from_payload(*sig)
             if name in methods:
                 _LOGGER.debug(
-                    "Got duplicate signature for %s, existing was %s, keeping it.",
+                    "Got another signature for %s, previous was %s, adding as %s.",
                     parsed_sig,
                     methods[name],
+                    f"{name}_{version}",
                 )
+                methods[f"{name}_{version}"] = Method(service, parsed_sig, debug)
             else:
                 methods[name] = Method(service, parsed_sig, debug)
 


### PR DESCRIPTION
I have added support for `getCurrentExternalTerminalsStatus` `version 1.2` API used for 
```
songpal input
songpal zone
```
Support for `version 1.0` remains, and I tested with a STR-DN1080.

This is the version used by the STR-AN1000. It also has a slightly different method for specifying the active input and the `notifyPlayingContentInfo` notification is slightly different. The Sony API site is closed, and this version isn't documented. I captured traffic between 'Music Center' IOS app and my receiver.

I have also updated so that the following work on the STR-AN1000. Looking at the documented API, a `target` parameter can be specified or an empty string `""` for all targets. This one could be a breaking change as the 
```
sony speaker
sony eq
```

I didn't want to understand all the code, so this is a quick attempt to be able to test it with Home Assistant. There are a number of newer API methods, which might warrant a better overall design to support multiple versions than my quick hack. I wanted to change as little code as possible and get feedback.

This doesn't fix all of the commands, for instance, `songpal source` is broken. However, my aim was just to get the Home Assistant integration working, plus a little extra.

Discussion and possible fix for #130