### PR TITLE
Add support for versioned methods used by newer devices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ The library has been tested to work with following devices:
 * SRS-X77, SRS-X88, SRS-X99
 * STR-DN1060, STR-DN1070, STR-DN1080
 * STR-AZ5000ES (not reporting all inputs)
+* STR-AN1000
 
 .. NOTE::
 

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,8 @@ The library has been tested to work with following devices:
 * HT-ST5000
 * SRS-X77, SRS-X88, SRS-X99
 * STR-DN1060, STR-DN1070, STR-DN1080
-* STR-AZ5000ES (not reporting all inputs)
-* STR-AN1000
+* STR-AZ5000ES
+* STR-AN1000, TA-AN1000
 
 .. NOTE::
 

--- a/devinfos/STR-AN1000.json
+++ b/devinfos/STR-AN1000.json
@@ -1,0 +1,2098 @@
+{
+    "interface_info": {
+        "interfaceVersion": "6.1.0",
+        "modelName": "STR-AN1000",
+        "productCategory": "homeTheaterSystem",
+        "productName": "SoundBar",
+        "serverName": ""
+    },
+    "settings": [
+        {
+            "apiMapping": null,
+            "deviceUIInfo": null,
+            "isAvailable": true,
+            "settings": [
+                {
+                    "apiMapping": null,
+                    "deviceUIInfo": null,
+                    "isAvailable": true,
+                    "settings": [
+                        {
+                            "apiMapping": null,
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": [
+                                {
+                                    "apiMapping": null,
+                                    "deviceUIInfo": "sliderAndEnum",
+                                    "isAvailable": true,
+                                    "settings": [
+                                        {
+                                            "apiMapping": {
+                                                "getApi": {
+                                                    "name": "getCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "service": "audio",
+                                                "setApi": {
+                                                    "name": "setCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "target": "frontBassLevel",
+                                                "targetSuppl": null
+                                            },
+                                            "deviceUIInfo": "sliderVertical",
+                                            "isAvailable": true,
+                                            "settings": null,
+                                            "title": "Front Bass Level",
+                                            "titleTextID": "sound-equalizer-front-bass",
+                                            "type": "integerTarget",
+                                            "usage": null
+                                        },
+                                        {
+                                            "apiMapping": {
+                                                "getApi": {
+                                                    "name": "getCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "service": "audio",
+                                                "setApi": {
+                                                    "name": "setCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "target": "frontTrebleLevel",
+                                                "targetSuppl": null
+                                            },
+                                            "deviceUIInfo": "sliderVertical",
+                                            "isAvailable": true,
+                                            "settings": null,
+                                            "title": "Front Treble Level",
+                                            "titleTextID": "sound-equalizer-front-treble",
+                                            "type": "integerTarget",
+                                            "usage": null
+                                        }
+                                    ],
+                                    "title": "Front",
+                                    "titleTextID": "sound-equalizer-front",
+                                    "type": "directory",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": null,
+                                    "deviceUIInfo": "sliderAndEnum",
+                                    "isAvailable": true,
+                                    "settings": [
+                                        {
+                                            "apiMapping": {
+                                                "getApi": {
+                                                    "name": "getCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "service": "audio",
+                                                "setApi": {
+                                                    "name": "setCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "target": "centerBassLevel",
+                                                "targetSuppl": null
+                                            },
+                                            "deviceUIInfo": "sliderVertical",
+                                            "isAvailable": true,
+                                            "settings": null,
+                                            "title": "Center Bass Level",
+                                            "titleTextID": "sound-equalizer-center-bass",
+                                            "type": "integerTarget",
+                                            "usage": null
+                                        },
+                                        {
+                                            "apiMapping": {
+                                                "getApi": {
+                                                    "name": "getCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "service": "audio",
+                                                "setApi": {
+                                                    "name": "setCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "target": "centerTrebleLevel",
+                                                "targetSuppl": null
+                                            },
+                                            "deviceUIInfo": "sliderVertical",
+                                            "isAvailable": true,
+                                            "settings": null,
+                                            "title": "Center Treble Level",
+                                            "titleTextID": "sound-equalizer-center-treble",
+                                            "type": "integerTarget",
+                                            "usage": null
+                                        }
+                                    ],
+                                    "title": "Center Level",
+                                    "titleTextID": "sound-equalizer-center",
+                                    "type": "directory",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": null,
+                                    "deviceUIInfo": "sliderAndEnum",
+                                    "isAvailable": true,
+                                    "settings": [
+                                        {
+                                            "apiMapping": {
+                                                "getApi": {
+                                                    "name": "getCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "service": "audio",
+                                                "setApi": {
+                                                    "name": "setCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "target": "surroundBassLevel",
+                                                "targetSuppl": null
+                                            },
+                                            "deviceUIInfo": "sliderVertical",
+                                            "isAvailable": true,
+                                            "settings": null,
+                                            "title": "Surround Bass Level",
+                                            "titleTextID": "sound-equalizer-surround-surroundback-bass",
+                                            "type": "integerTarget",
+                                            "usage": null
+                                        },
+                                        {
+                                            "apiMapping": {
+                                                "getApi": {
+                                                    "name": "getCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "service": "audio",
+                                                "setApi": {
+                                                    "name": "setCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "target": "surroundTrebleLevel",
+                                                "targetSuppl": null
+                                            },
+                                            "deviceUIInfo": "sliderVertical",
+                                            "isAvailable": true,
+                                            "settings": null,
+                                            "title": "Surround Treble Level",
+                                            "titleTextID": "sound-equalizer-surround-surroundback-treble",
+                                            "type": "integerTarget",
+                                            "usage": null
+                                        }
+                                    ],
+                                    "title": "Surround/Surround Back",
+                                    "titleTextID": "sound-equalizer-surround-surroundback",
+                                    "type": "directory",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": null,
+                                    "deviceUIInfo": "sliderAndEnum",
+                                    "isAvailable": true,
+                                    "settings": [
+                                        {
+                                            "apiMapping": {
+                                                "getApi": {
+                                                    "name": "getCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "service": "audio",
+                                                "setApi": {
+                                                    "name": "setCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "target": "heightBassLevel",
+                                                "targetSuppl": null
+                                            },
+                                            "deviceUIInfo": "sliderVertical",
+                                            "isAvailable": true,
+                                            "settings": null,
+                                            "title": "Height1 Bass Level",
+                                            "titleTextID": "sound-equalizer-height1-bass",
+                                            "type": "integerTarget",
+                                            "usage": null
+                                        },
+                                        {
+                                            "apiMapping": {
+                                                "getApi": {
+                                                    "name": "getCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "service": "audio",
+                                                "setApi": {
+                                                    "name": "setCustomEqualizerSettings",
+                                                    "version": "1.0"
+                                                },
+                                                "target": "heightTrebleLevel",
+                                                "targetSuppl": null
+                                            },
+                                            "deviceUIInfo": "sliderVertical",
+                                            "isAvailable": true,
+                                            "settings": null,
+                                            "title": "Height1 Treble Level",
+                                            "titleTextID": "sound-equalizer-height1-treble",
+                                            "type": "integerTarget",
+                                            "usage": null
+                                        }
+                                    ],
+                                    "title": "Height1",
+                                    "titleTextID": "sound-equalizer-height1",
+                                    "type": "directory",
+                                    "usage": null
+                                }
+                            ],
+                            "title": "Equalizer",
+                            "titleTextID": "sound-equalizer",
+                            "type": "directory",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "service": "audio",
+                                "setApi": {
+                                    "name": "setSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "target": "soundField",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": "soundFieldFig",
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "Sound Field",
+                            "titleTextID": "sound-soundfield",
+                            "type": "enumTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "service": "audio",
+                                "setApi": {
+                                    "name": "setSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "target": "dsdNative",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "DSD Native",
+                            "titleTextID": "sound-dsdnative",
+                            "type": "enumTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "service": "audio",
+                                "setApi": {
+                                    "name": "setSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "target": "pureDirect",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "Pure Direct",
+                            "titleTextID": "sound-puredirect",
+                            "type": "booleanTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getSpeakerSettings",
+                                    "version": "1.0"
+                                },
+                                "service": "audio",
+                                "setApi": {
+                                    "name": "setSpeakerSettings",
+                                    "version": "1.0"
+                                },
+                                "target": "inCeilingSpeakerMode",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "In-Ceiling Speaker Mode",
+                            "titleTextID": "sound-inceiling",
+                            "type": "enumTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "service": "audio",
+                                "setApi": {
+                                    "name": "setSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "target": "360SSM",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "360 Spatial Sound Mapping",
+                            "titleTextID": "sound-360ssm",
+                            "type": "enumTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "service": "audio",
+                                "setApi": {
+                                    "name": "setSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "target": "calibrationType",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "Calibration Type",
+                            "titleTextID": "sound-calibrationtype",
+                            "type": "enumTarget",
+                            "usage": null
+                        }
+                    ],
+                    "title": "Sound Setting",
+                    "titleTextID": "sound",
+                    "type": "directory",
+                    "usage": null
+                },
+                {
+                    "apiMapping": null,
+                    "deviceUIInfo": null,
+                    "isAvailable": true,
+                    "settings": [
+                        {
+                            "apiMapping": null,
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": [
+                                {
+                                    "apiMapping": {
+                                        "getApi": {
+                                            "name": "getSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "service": "audio",
+                                        "setApi": {
+                                            "name": "setSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "target": "frontLLevel",
+                                        "targetSuppl": null
+                                    },
+                                    "deviceUIInfo": "picker",
+                                    "isAvailable": true,
+                                    "settings": null,
+                                    "title": "Front L Level",
+                                    "titleTextID": "speaker-speakerlevel-frontl",
+                                    "type": "doubleNumberTarget",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": {
+                                        "getApi": {
+                                            "name": "getSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "service": "audio",
+                                        "setApi": {
+                                            "name": "setSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "target": "frontRLevel",
+                                        "targetSuppl": null
+                                    },
+                                    "deviceUIInfo": "picker",
+                                    "isAvailable": true,
+                                    "settings": null,
+                                    "title": "Front R Level",
+                                    "titleTextID": "speaker-speakerlevel-frontr",
+                                    "type": "doubleNumberTarget",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": {
+                                        "getApi": {
+                                            "name": "getSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "service": "audio",
+                                        "setApi": {
+                                            "name": "setSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "target": "centerLevel",
+                                        "targetSuppl": null
+                                    },
+                                    "deviceUIInfo": "picker",
+                                    "isAvailable": true,
+                                    "settings": null,
+                                    "title": "Center Level",
+                                    "titleTextID": "speaker-speakerlevel-center",
+                                    "type": "doubleNumberTarget",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": {
+                                        "getApi": {
+                                            "name": "getSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "service": "audio",
+                                        "setApi": {
+                                            "name": "setSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "target": "tvCenterLevel",
+                                        "targetSuppl": null
+                                    },
+                                    "deviceUIInfo": "picker",
+                                    "isAvailable": true,
+                                    "settings": null,
+                                    "title": "TV Center Level",
+                                    "titleTextID": "speaker-speakerlevel-tvcenterlevel",
+                                    "type": "doubleNumberTarget",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": {
+                                        "getApi": {
+                                            "name": "getSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "service": "audio",
+                                        "setApi": {
+                                            "name": "setSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "target": "surroundLLevel",
+                                        "targetSuppl": null
+                                    },
+                                    "deviceUIInfo": "picker",
+                                    "isAvailable": true,
+                                    "settings": null,
+                                    "title": "Surround L Level",
+                                    "titleTextID": "speaker-speakerlevel-surroundllevel",
+                                    "type": "doubleNumberTarget",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": {
+                                        "getApi": {
+                                            "name": "getSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "service": "audio",
+                                        "setApi": {
+                                            "name": "setSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "target": "surroundRLevel",
+                                        "targetSuppl": null
+                                    },
+                                    "deviceUIInfo": "picker",
+                                    "isAvailable": true,
+                                    "settings": null,
+                                    "title": "Surround R Level",
+                                    "titleTextID": "speaker-speakerlevel-surroundrlevel",
+                                    "type": "doubleNumberTarget",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": {
+                                        "getApi": {
+                                            "name": "getSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "service": "audio",
+                                        "setApi": {
+                                            "name": "setSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "target": "highLLevel",
+                                        "targetSuppl": null
+                                    },
+                                    "deviceUIInfo": "picker",
+                                    "isAvailable": true,
+                                    "settings": null,
+                                    "title": "Height L Level",
+                                    "titleTextID": "speaker-speakerlevel-heigth1llevel",
+                                    "type": "doubleNumberTarget",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": {
+                                        "getApi": {
+                                            "name": "getSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "service": "audio",
+                                        "setApi": {
+                                            "name": "setSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "target": "highRLevel",
+                                        "targetSuppl": null
+                                    },
+                                    "deviceUIInfo": "picker",
+                                    "isAvailable": true,
+                                    "settings": null,
+                                    "title": "Height R Level",
+                                    "titleTextID": "speaker-speakerlevel-heigth1rlevel",
+                                    "type": "doubleNumberTarget",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": {
+                                        "getApi": {
+                                            "name": "getSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "service": "audio",
+                                        "setApi": {
+                                            "name": "setSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "target": "surroundBackLLevel",
+                                        "targetSuppl": null
+                                    },
+                                    "deviceUIInfo": "picker",
+                                    "isAvailable": true,
+                                    "settings": null,
+                                    "title": "Surround Back L Level",
+                                    "titleTextID": "speaker-speakerlevel-surroundbackllevel",
+                                    "type": "doubleNumberTarget",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": {
+                                        "getApi": {
+                                            "name": "getSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "service": "audio",
+                                        "setApi": {
+                                            "name": "setSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "target": "surroundBackRLevel",
+                                        "targetSuppl": null
+                                    },
+                                    "deviceUIInfo": "picker",
+                                    "isAvailable": true,
+                                    "settings": null,
+                                    "title": "Surround Back R Level",
+                                    "titleTextID": "speaker-speakerlevel-surroundbackrlevel",
+                                    "type": "doubleNumberTarget",
+                                    "usage": null
+                                },
+                                {
+                                    "apiMapping": {
+                                        "getApi": {
+                                            "name": "getSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "service": "audio",
+                                        "setApi": {
+                                            "name": "setSpeakerSettings",
+                                            "version": "1.0"
+                                        },
+                                        "target": "subwooferLevel",
+                                        "targetSuppl": null
+                                    },
+                                    "deviceUIInfo": "picker",
+                                    "isAvailable": true,
+                                    "settings": null,
+                                    "title": "Subwoofer Level",
+                                    "titleTextID": "speaker-speakerlevel-subwooferlevel",
+                                    "type": "doubleNumberTarget",
+                                    "usage": null
+                                }
+                            ],
+                            "title": "Level",
+                            "titleTextID": "speaker-speakerlevel",
+                            "type": "directory",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getSpeakerSettings",
+                                    "version": "1.0"
+                                },
+                                "service": "audio",
+                                "setApi": {
+                                    "name": "setSpeakerSettings",
+                                    "version": "1.0"
+                                },
+                                "target": "speakerSelection",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "Speakers",
+                            "titleTextID": "speaker-speakers",
+                            "type": "enumTarget",
+                            "usage": null
+                        }
+                    ],
+                    "title": "Speaker",
+                    "titleTextID": "speaker",
+                    "type": "directory",
+                    "usage": null
+                },
+                {
+                    "apiMapping": null,
+                    "deviceUIInfo": null,
+                    "isAvailable": true,
+                    "settings": [
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "service": "audio",
+                                "setApi": {
+                                    "name": "setSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "target": "sceneSelection",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "Custom Preset",
+                            "titleTextID": "custompreset-custompreset",
+                            "type": "enumTarget",
+                            "usage": null
+                        }
+                    ],
+                    "title": "Custom Preset",
+                    "titleTextID": "custompreset",
+                    "type": "directory",
+                    "usage": null
+                },
+                {
+                    "apiMapping": null,
+                    "deviceUIInfo": null,
+                    "isAvailable": true,
+                    "settings": [
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getSWUpdateInfo",
+                                    "version": "1.0"
+                                },
+                                "service": "system",
+                                "setApi": {
+                                    "name": "actSWUpdate",
+                                    "version": "1.0"
+                                },
+                                "target": null,
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": false,
+                            "settings": null,
+                            "title": "Software Update",
+                            "titleTextID": "system-update",
+                            "type": "nullTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getPowerSettings",
+                                    "version": "1.0"
+                                },
+                                "service": "system",
+                                "setApi": {
+                                    "name": "setPowerSettings",
+                                    "version": "1.0"
+                                },
+                                "target": "quickStartMode",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": "",
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "Network / Bluetooth Standby",
+                            "titleTextID": "system-networkstandby",
+                            "type": "booleanTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "service": "audio",
+                                "setApi": {
+                                    "name": "setSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "target": "dimmer",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": "",
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "Dimmer",
+                            "titleTextID": "system-dimmer",
+                            "type": "enumTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "service": "audio",
+                                "setApi": {
+                                    "name": "setSoundSettings",
+                                    "version": "1.1"
+                                },
+                                "target": "hdmiOutput",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": "",
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "HDMI Output",
+                            "titleTextID": "system-hdimoutput",
+                            "type": "enumTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getDeviceMiscSettings",
+                                    "version": "1.0"
+                                },
+                                "service": "system",
+                                "setApi": {
+                                    "name": "setDeviceMiscSettings",
+                                    "version": "1.0"
+                                },
+                                "target": "deviceName",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "Device Name",
+                            "titleTextID": "system-networkdevicename",
+                            "type": "stringTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getDeviceMiscSettings",
+                                    "version": "1.0"
+                                },
+                                "service": "system",
+                                "setApi": {
+                                    "name": "setDeviceMiscSettings",
+                                    "version": "1.0"
+                                },
+                                "target": "swAutoUpdate",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "Auto Update ",
+                            "titleTextID": "system-autoupdate",
+                            "type": "booleanTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getDeviceMiscSettings",
+                                    "version": "1.0"
+                                },
+                                "service": "system",
+                                "setApi": {
+                                    "name": "setDeviceMiscSettings",
+                                    "version": "1.0"
+                                },
+                                "target": "timeZone",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "Time Zone",
+                            "titleTextID": "system-timezone",
+                            "type": "stringTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getSystemInformation",
+                                    "version": "1.3"
+                                },
+                                "service": "system",
+                                "setApi": null,
+                                "target": "",
+                                "targetSuppl": "version"
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "STR-AN1000 Software Version",
+                            "titleTextID": "other-htversion-TBD",
+                            "type": "stringTarget",
+                            "usage": null
+                        }
+                    ],
+                    "title": "Setting",
+                    "titleTextID": "system",
+                    "type": "directory",
+                    "usage": null
+                }
+            ],
+            "title": null,
+            "titleTextID": null,
+            "type": "directory",
+            "usage": "deviceConfig"
+        },
+        {
+            "apiMapping": null,
+            "deviceUIInfo": null,
+            "isAvailable": true,
+            "settings": [
+                {
+                    "apiMapping": null,
+                    "deviceUIInfo": null,
+                    "isAvailable": true,
+                    "settings": [
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getPlaybackModeSettings",
+                                    "version": "1.0"
+                                },
+                                "service": "avContent",
+                                "setApi": {
+                                    "name": "setPlaybackModeSettings",
+                                    "version": "1.1"
+                                },
+                                "target": "repeatType",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "Repeat",
+                            "titleTextID": "playbackMode-repeatType",
+                            "type": "enumTarget",
+                            "usage": null
+                        },
+                        {
+                            "apiMapping": {
+                                "getApi": {
+                                    "name": "getPlaybackModeSettings",
+                                    "version": "1.0"
+                                },
+                                "service": "avContent",
+                                "setApi": {
+                                    "name": "setPlaybackModeSettings",
+                                    "version": "1.1"
+                                },
+                                "target": "shuffleType",
+                                "targetSuppl": null
+                            },
+                            "deviceUIInfo": null,
+                            "isAvailable": true,
+                            "settings": null,
+                            "title": "Shuffle",
+                            "titleTextID": "playbackMode-shuffleType",
+                            "type": "enumTarget",
+                            "usage": null
+                        }
+                    ],
+                    "title": "Playback Mode",
+                    "titleTextID": "playbackMode",
+                    "type": "directory",
+                    "usage": null
+                }
+            ],
+            "title": null,
+            "titleTextID": null,
+            "type": "directory",
+            "usage": "playingControl"
+        },
+        {
+            "apiMapping": null,
+            "deviceUIInfo": null,
+            "isAvailable": true,
+            "settings": [
+                {
+                    "apiMapping": {
+                        "getApi": {
+                            "name": "getPowerSettings",
+                            "version": "1.0"
+                        },
+                        "service": "system",
+                        "setApi": {
+                            "name": "setPowerSettings",
+                            "version": "1.0"
+                        },
+                        "target": "quickStartMode",
+                        "targetSuppl": null
+                    },
+                    "deviceUIInfo": "",
+                    "isAvailable": true,
+                    "settings": null,
+                    "title": "Network / Bluetooth Standby",
+                    "titleTextID": "system-networkstandby",
+                    "type": "booleanTarget",
+                    "usage": null
+                },
+                {
+                    "apiMapping": {
+                        "getApi": {
+                            "name": "getDeviceMiscSettings",
+                            "version": "1.0"
+                        },
+                        "service": "system",
+                        "setApi": {
+                            "name": "setDeviceMiscSettings",
+                            "version": "1.0"
+                        },
+                        "target": "swAutoUpdate",
+                        "targetSuppl": null
+                    },
+                    "deviceUIInfo": null,
+                    "isAvailable": true,
+                    "settings": null,
+                    "title": "Auto Update ",
+                    "titleTextID": "system-autoupdate",
+                    "type": "booleanTarget",
+                    "usage": null
+                },
+                {
+                    "apiMapping": {
+                        "getApi": {
+                            "name": "getDeviceMiscSettings",
+                            "version": "1.0"
+                        },
+                        "service": "system",
+                        "setApi": {
+                            "name": "setDeviceMiscSettings",
+                            "version": "1.0"
+                        },
+                        "target": "timeZone",
+                        "targetSuppl": null
+                    },
+                    "deviceUIInfo": null,
+                    "isAvailable": true,
+                    "settings": null,
+                    "title": "Time Zone",
+                    "titleTextID": "system-timezone",
+                    "type": "stringTarget",
+                    "usage": null
+                }
+            ],
+            "title": null,
+            "titleTextID": null,
+            "type": "directory",
+            "usage": "initialSetting"
+        }
+    ],
+    "supported_methods": {
+        "appControl": {
+            "methods": {
+                "getApplicationList": {
+                    "input": {
+                        "os": "str",
+                        "type": "str"
+                    },
+                    "name": "getApplicationList",
+                    "output": {
+                        "isAvailable": "bool",
+                        "service": "ApplicationList[]"
+                    },
+                    "service": "appControl",
+                    "version": "1.2"
+                },
+                "getMethodTypes": {
+                    "input": "str",
+                    "name": "getMethodTypes",
+                    "output": "str",
+                    "service": "appControl",
+                    "version": "1.0"
+                },
+                "getVersions": {
+                    "input": null,
+                    "name": "getVersions",
+                    "output": "str",
+                    "service": "appControl",
+                    "version": "1.0"
+                },
+                "switchNotifications": {
+                    "input": {
+                        "disabled": "ApiIdentity[]",
+                        "enabled": "ApiIdentity[]"
+                    },
+                    "name": "switchNotifications",
+                    "output": {
+                        "disabled": "ApiIdentity[]",
+                        "enabled": "ApiIdentity[]",
+                        "rejected": "ApiIdentity[]",
+                        "unsupported": "ApiIdentity[]"
+                    },
+                    "service": "appControl",
+                    "version": "1.0"
+                }
+            },
+            "notifications": {},
+            "protocols": []
+        },
+        "audio": {
+            "methods": {
+                "getCustomEqualizerSettings": {
+                    "input": {
+                        "target": "str"
+                    },
+                    "name": "getCustomEqualizerSettings",
+                    "output": {
+                        "candidate": "GeneralSettingsCandidate[]",
+                        "currentValue": "str",
+                        "deviceUIInfo": "str",
+                        "isAvailable": "bool",
+                        "target": "str",
+                        "title": "str",
+                        "titleTextID": "str",
+                        "type": "str"
+                    },
+                    "service": "audio",
+                    "version": "1.0"
+                },
+                "getMethodTypes": {
+                    "input": "str",
+                    "name": "getMethodTypes",
+                    "output": "str",
+                    "service": "audio",
+                    "version": "1.0"
+                },
+                "getSoundSettings": {
+                    "input": {
+                        "target": "str"
+                    },
+                    "name": "getSoundSettings",
+                    "output": {
+                        "candidate": "GeneralSettingsCandidate[]",
+                        "currentValue": "str",
+                        "deviceUIInfo": "str",
+                        "isAvailable": "bool",
+                        "target": "str",
+                        "title": "str",
+                        "titleTextID": "str",
+                        "type": "str"
+                    },
+                    "service": "audio",
+                    "version": "1.1"
+                },
+                "getSpeakerSettings": {
+                    "input": {
+                        "target": "str"
+                    },
+                    "name": "getSpeakerSettings",
+                    "output": {
+                        "candidate": "GeneralSettingsCandidate[]",
+                        "currentValue": "str",
+                        "deviceUIInfo": "str",
+                        "isAvailable": "bool",
+                        "target": "str",
+                        "title": "str",
+                        "titleTextID": "str",
+                        "type": "str"
+                    },
+                    "service": "audio",
+                    "version": "1.0"
+                },
+                "getVersions": {
+                    "input": null,
+                    "name": "getVersions",
+                    "output": "str",
+                    "service": "audio",
+                    "version": "1.0"
+                },
+                "getVolumeInformation": {
+                    "input": {
+                        "output": "str"
+                    },
+                    "name": "getVolumeInformation",
+                    "output": {
+                        "maxVolume": "int",
+                        "minVolume": "int",
+                        "mute": "str",
+                        "output": "str",
+                        "step": "int",
+                        "volume": "int"
+                    },
+                    "service": "audio",
+                    "version": "1.1"
+                },
+                "setAudioMute": {
+                    "input": {
+                        "mute": "str",
+                        "output": "str"
+                    },
+                    "name": "setAudioMute",
+                    "output": null,
+                    "service": "audio",
+                    "version": "1.1"
+                },
+                "setAudioVolume": {
+                    "input": {
+                        "output": "str",
+                        "volume": "str"
+                    },
+                    "name": "setAudioVolume",
+                    "output": null,
+                    "service": "audio",
+                    "version": "1.1"
+                },
+                "setCustomEqualizerSettings": {
+                    "input": {
+                        "settings": "GeneralSettings[]"
+                    },
+                    "name": "setCustomEqualizerSettings",
+                    "output": null,
+                    "service": "audio",
+                    "version": "1.0"
+                },
+                "setSoundSettings": {
+                    "input": {
+                        "settings": "GeneralSettings[]"
+                    },
+                    "name": "setSoundSettings",
+                    "output": null,
+                    "service": "audio",
+                    "version": "1.1"
+                },
+                "setSpeakerSettings": {
+                    "input": {
+                        "settings": "GeneralSettings[]"
+                    },
+                    "name": "setSpeakerSettings",
+                    "output": null,
+                    "service": "audio",
+                    "version": "1.0"
+                },
+                "switchNotifications": {
+                    "input": {
+                        "disabled": "ApiIdentity[]",
+                        "enabled": "ApiIdentity[]"
+                    },
+                    "name": "switchNotifications",
+                    "output": {
+                        "disabled": "ApiIdentity[]",
+                        "enabled": "ApiIdentity[]",
+                        "rejected": "ApiIdentity[]",
+                        "unsupported": "ApiIdentity[]"
+                    },
+                    "service": "audio",
+                    "version": "1.0"
+                }
+            },
+            "notifications": {
+                "notifyVolumeInformation": {
+                    "name": "notifyVolumeInformation",
+                    "version": "1.0"
+                }
+            },
+            "protocols": []
+        },
+        "avContent": {
+            "methods": {
+                "getAvailablePlaybackFunction": {
+                    "input": {
+                        "output": "str"
+                    },
+                    "name": "getAvailablePlaybackFunction",
+                    "output": {
+                        "functions": "FunctionInfo[]",
+                        "output": "str",
+                        "uri": "str"
+                    },
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "getBluetoothSettings": {
+                    "input": {
+                        "target": "str"
+                    },
+                    "name": "getBluetoothSettings",
+                    "output": {
+                        "candidate": "GeneralSettingsCandidate[]",
+                        "currentValue": "str",
+                        "deviceUIInfo": "str",
+                        "isAvailable": "bool",
+                        "target": "str",
+                        "title": "str",
+                        "titleTextID": "str",
+                        "type": "str"
+                    },
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "getContentCount": {
+                    "input": {
+                        "target": "str",
+                        "type": "string*",
+                        "uri": "str",
+                        "view": "str"
+                    },
+                    "name": "getContentCount",
+                    "output": {
+                        "capability": "int",
+                        "count": "int"
+                    },
+                    "service": "avContent",
+                    "version": "1.3"
+                },
+                "getContentList": {
+                    "input": {
+                        "cnt": "int",
+                        "sort": "str",
+                        "stIdx": "int",
+                        "target": "str",
+                        "type": "string*",
+                        "uri": "str",
+                        "view": "str"
+                    },
+                    "name": "getContentList",
+                    "output": {
+                        "albumName": "str",
+                        "artist": "str",
+                        "audioInfo": "AudioInfo[]",
+                        "broadcastFreq": "int",
+                        "broadcastFreqBand": "str",
+                        "channelName": "str",
+                        "channelSurfingVisibility": "str",
+                        "chapterCount": "int",
+                        "content": "ContentInfo",
+                        "contentKind": "str",
+                        "contentType": "str",
+                        "createdTime": "str",
+                        "directRemoteNum": "int",
+                        "dispNum": "str",
+                        "durationMsec": "int",
+                        "epgVisibility": "str",
+                        "fileNo": "str",
+                        "fileSizeByte": "int",
+                        "folderNo": "str",
+                        "genre": "string*",
+                        "index": "int",
+                        "isAlreadyPlayed": "str",
+                        "isBrowsable": "str",
+                        "isPlayable": "str",
+                        "isProtected": "str",
+                        "originalDispNum": "str",
+                        "parentUri": "str",
+                        "parentalInfo": "ParentalInfo[]",
+                        "playlistName": "str",
+                        "podcastName": "str",
+                        "productID": "str",
+                        "programMediaType": "str",
+                        "programNum": "int",
+                        "remotePlayType": "string*",
+                        "sizeMB": "int",
+                        "startDateTime": "str",
+                        "storageUri": "str",
+                        "subtitleInfo": "SubtitleInfo[]",
+                        "title": "str",
+                        "tripletStr": "str",
+                        "uri": "str",
+                        "userContentFlag": "bool",
+                        "videoInfo": "VideoInfo",
+                        "visibility": "str"
+                    },
+                    "service": "avContent",
+                    "version": "1.4"
+                },
+                "getCurrentExternalTerminalsStatus": {
+                    "input": {
+                        "uri": "str"
+                    },
+                    "name": "getCurrentExternalTerminalsStatus",
+                    "output": {
+                        "active": "str",
+                        "avOutput": "str",
+                        "connection": "str",
+                        "iconId": "str",
+                        "iconUrl": "str",
+                        "label": "str",
+                        "meta": "str",
+                        "outputs": "string*",
+                        "title": "str",
+                        "uri": "str"
+                    },
+                    "service": "avContent",
+                    "version": "1.2"
+                },
+                "getMethodTypes": {
+                    "input": "str",
+                    "name": "getMethodTypes",
+                    "output": "str",
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "getPlaybackModeSettings": {
+                    "input": {
+                        "target": "str",
+                        "uri": "str"
+                    },
+                    "name": "getPlaybackModeSettings",
+                    "output": {
+                        "candidate": "PlaybackModeSettingsCandidate[]",
+                        "currentValue": "str",
+                        "deviceUIInfo": "str",
+                        "isAvailable": "bool",
+                        "target": "str",
+                        "title": "str",
+                        "titleTextID": "str",
+                        "type": "str",
+                        "uri": "str"
+                    },
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "getPlayingContentInfo": {
+                    "input": {
+                        "output": "str"
+                    },
+                    "name": "getPlayingContentInfo",
+                    "output": {
+                        "albumName": "str",
+                        "applicationName": "str",
+                        "artist": "str",
+                        "audioInfo": "AudioInfo[]",
+                        "bivl_assetId": "str",
+                        "bivl_provider": "str",
+                        "bivl_serviceId": "str",
+                        "broadcastFreq": "int",
+                        "broadcastFreqBand": "str",
+                        "channelName": "str",
+                        "chapterCount": "int",
+                        "chapterIndex": "int",
+                        "contentKind": "str",
+                        "dabInfo": "DabInfo",
+                        "dispNum": "str",
+                        "durationMsec": "int",
+                        "durationSec": "double",
+                        "fileNo": "str",
+                        "genre": "string*",
+                        "index": "int",
+                        "mediaType": "str",
+                        "originalDispNum": "str",
+                        "output": "str",
+                        "parentUri": "str",
+                        "playSpeed": "str",
+                        "playSpeedStep": "int",
+                        "playlistName": "str",
+                        "podcastName": "str",
+                        "positionMsec": "int",
+                        "positionSec": "double",
+                        "programNum": "int",
+                        "programTitle": "str",
+                        "repeatType": "str",
+                        "service": "str",
+                        "source": "str",
+                        "sourceLabel": "str",
+                        "startDateTime": "str",
+                        "stateInfo": "StateInfo",
+                        "subtitleIndex": "int",
+                        "title": "str",
+                        "totalCount": "int",
+                        "tripletStr": "str",
+                        "uri": "str",
+                        "videoInfo": "VideoInfo"
+                    },
+                    "service": "avContent",
+                    "version": "1.2"
+                },
+                "getSchemeList": {
+                    "input": null,
+                    "name": "getSchemeList",
+                    "output": {
+                        "scheme": "str"
+                    },
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "getSourceList": {
+                    "input": {
+                        "scheme": "str"
+                    },
+                    "name": "getSourceList",
+                    "output": {
+                        "iconId": "str",
+                        "iconUrl": "str",
+                        "isBrowsable": "bool",
+                        "isPlayable": "bool",
+                        "meta": "str",
+                        "outputs": "string*",
+                        "playAction": "str",
+                        "protocols": "string*",
+                        "source": "str",
+                        "title": "str",
+                        "upnpOperationInfo": "UpnpOperationInfo"
+                    },
+                    "service": "avContent",
+                    "version": "1.3"
+                },
+                "getSupportedPlaybackFunction": {
+                    "input": {
+                        "uri": "str"
+                    },
+                    "name": "getSupportedPlaybackFunction",
+                    "output": {
+                        "functions": "SupportedFunctionInfo[]",
+                        "uri": "str"
+                    },
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "getVersions": {
+                    "input": null,
+                    "name": "getVersions",
+                    "output": "str",
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "pausePlayingContent": {
+                    "input": {
+                        "output": "str"
+                    },
+                    "name": "pausePlayingContent",
+                    "output": null,
+                    "service": "avContent",
+                    "version": "1.1"
+                },
+                "presetBroadcastStation": {
+                    "input": {
+                        "frequency": "int",
+                        "uri": "str"
+                    },
+                    "name": "presetBroadcastStation",
+                    "output": null,
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "scanPlayingContent": {
+                    "input": {
+                        "direction": "str",
+                        "output": "str"
+                    },
+                    "name": "scanPlayingContent",
+                    "output": null,
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "seekBroadcastStation": {
+                    "input": {
+                        "direction": "str",
+                        "tuning": "str"
+                    },
+                    "name": "seekBroadcastStation",
+                    "output": null,
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "setActiveTerminal": {
+                    "input": {
+                        "active": "str",
+                        "uri": "str"
+                    },
+                    "name": "setActiveTerminal",
+                    "output": null,
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "setBluetoothSettings": {
+                    "input": {
+                        "settings": "GeneralSettings[]"
+                    },
+                    "name": "setBluetoothSettings",
+                    "output": null,
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "setPlayContent": {
+                    "input": {
+                        "keepLastFrame": "bool",
+                        "output": "str",
+                        "positionMsec": "int",
+                        "positionSec": "double",
+                        "repeatType": "str",
+                        "requester": "str",
+                        "resume": "bool",
+                        "uri": "str"
+                    },
+                    "name": "setPlayContent",
+                    "output": null,
+                    "service": "avContent",
+                    "version": "1.2"
+                },
+                "setPlayNextContent": {
+                    "input": {
+                        "output": "str"
+                    },
+                    "name": "setPlayNextContent",
+                    "output": null,
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "setPlayPreviousContent": {
+                    "input": {
+                        "output": "str"
+                    },
+                    "name": "setPlayPreviousContent",
+                    "output": null,
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "setPlaybackModeSettings": {
+                    "input": {
+                        "settings": "PlaybackModeSettings[]"
+                    },
+                    "name": "setPlaybackModeSettings",
+                    "output": null,
+                    "service": "avContent",
+                    "version": "1.1"
+                },
+                "startContentBrowsing": {
+                    "input": {
+                        "uri": "str"
+                    },
+                    "name": "startContentBrowsing",
+                    "output": {
+                        "errorMessage": "str",
+                        "status": "str"
+                    },
+                    "service": "avContent",
+                    "version": "1.0"
+                },
+                "stopPlayingContent": {
+                    "input": {
+                        "keepLastFrame": "bool",
+                        "output": "str"
+                    },
+                    "name": "stopPlayingContent",
+                    "output": null,
+                    "service": "avContent",
+                    "version": "1.1"
+                },
+                "switchNotifications": {
+                    "input": {
+                        "disabled": "ApiIdentity[]",
+                        "enabled": "ApiIdentity[]"
+                    },
+                    "name": "switchNotifications",
+                    "output": {
+                        "disabled": "ApiIdentity[]",
+                        "enabled": "ApiIdentity[]",
+                        "rejected": "ApiIdentity[]",
+                        "unsupported": "ApiIdentity[]"
+                    },
+                    "service": "avContent",
+                    "version": "1.0"
+                }
+            },
+            "notifications": {
+                "notifyAvailablePlaybackFunction": {
+                    "name": "notifyAvailablePlaybackFunction",
+                    "version": "1.0"
+                },
+                "notifyExternalTerminalStatus": {
+                    "name": "notifyExternalTerminalStatus",
+                    "version": "1.0"
+                },
+                "notifyPlayingContentInfo": {
+                    "name": "notifyPlayingContentInfo",
+                    "version": "1.0"
+                }
+            },
+            "protocols": []
+        },
+        "guide": {
+            "methods": {
+                "getMethodTypes": {
+                    "input": "str",
+                    "name": "getMethodTypes",
+                    "output": "str",
+                    "service": "guide",
+                    "version": "1.0"
+                },
+                "getSupportedApiInfo": {
+                    "input": {
+                        "services": "string*"
+                    },
+                    "name": "getSupportedApiInfo",
+                    "output": {
+                        "apis": "ApiInfo[]",
+                        "notifications": "NotificationInfo[]",
+                        "protocols": "string*",
+                        "service": "str"
+                    },
+                    "service": "guide",
+                    "version": "1.0"
+                },
+                "getVersions": {
+                    "input": null,
+                    "name": "getVersions",
+                    "output": "str",
+                    "service": "guide",
+                    "version": "1.0"
+                },
+                "switchNotifications": {
+                    "input": {
+                        "disabled": "ApiIdentity[]",
+                        "enabled": "ApiIdentity[]"
+                    },
+                    "name": "switchNotifications",
+                    "output": {
+                        "disabled": "ApiIdentity[]",
+                        "enabled": "ApiIdentity[]",
+                        "rejected": "ApiIdentity[]",
+                        "unsupported": "ApiIdentity[]"
+                    },
+                    "service": "guide",
+                    "version": "1.0"
+                }
+            },
+            "notifications": {},
+            "protocols": []
+        },
+        "system": {
+            "methods": {
+                "actSWUpdate": {
+                    "input": null,
+                    "name": "actSWUpdate",
+                    "output": null,
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "connectBluetoothDevice": {
+                    "input": {
+                        "bdAddr": "str"
+                    },
+                    "name": "connectBluetoothDevice",
+                    "output": null,
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "getAlexaDeviceInfo": {
+                    "input": {
+                        "encKey": "str"
+                    },
+                    "name": "getAlexaDeviceInfo",
+                    "output": {
+                        "codeChallenge": "str",
+                        "dsn": "str",
+                        "productID": "str"
+                    },
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "getAlexaRegistrationStatus": {
+                    "input": null,
+                    "name": "getAlexaRegistrationStatus",
+                    "output": {
+                        "status": "str"
+                    },
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "getDeviceMiscSettings": {
+                    "input": {
+                        "target": "str"
+                    },
+                    "name": "getDeviceMiscSettings",
+                    "output": {
+                        "candidate": "GeneralSettingsCandidate[]",
+                        "currentValue": "str",
+                        "deviceUIInfo": "str",
+                        "isAvailable": "bool",
+                        "target": "str",
+                        "title": "str",
+                        "titleTextID": "str",
+                        "type": "str"
+                    },
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "getEciaDeviceInfo": {
+                    "input": null,
+                    "name": "getEciaDeviceInfo",
+                    "output": {
+                        "deviceId": "str"
+                    },
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "getInterfaceInformation": {
+                    "input": null,
+                    "name": "getInterfaceInformation",
+                    "output": {
+                        "interfaceVersion": "str",
+                        "modelName": "str",
+                        "productCategory": "str",
+                        "productName": "str",
+                        "serverName": "str"
+                    },
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "getMethodTypes": {
+                    "input": "str",
+                    "name": "getMethodTypes",
+                    "output": "str",
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "getPowerSettings": {
+                    "input": {
+                        "target": "str"
+                    },
+                    "name": "getPowerSettings",
+                    "output": {
+                        "candidate": "GeneralSettingsCandidate[]",
+                        "currentValue": "str",
+                        "deviceUIInfo": "str",
+                        "isAvailable": "bool",
+                        "target": "str",
+                        "title": "str",
+                        "titleTextID": "str",
+                        "type": "str"
+                    },
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "getPowerStatus": {
+                    "input": null,
+                    "name": "getPowerStatus",
+                    "output": {
+                        "standbyDetail": "str",
+                        "status": "str"
+                    },
+                    "service": "system",
+                    "version": "1.1"
+                },
+                "getSWUpdateInfo": {
+                    "input": {
+                        "network": "str"
+                    },
+                    "name": "getSWUpdateInfo",
+                    "output": {
+                        "isUpdatable": "str",
+                        "swInfo": "SWInfo[]"
+                    },
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "getSettingsTree": {
+                    "input": {
+                        "usage": "str"
+                    },
+                    "name": "getSettingsTree",
+                    "output": {
+                        "settings": "SettingsTreeList[]"
+                    },
+                    "service": "system",
+                    "version": "1.1"
+                },
+                "getStorageList": {
+                    "input": {
+                        "uri": "str"
+                    },
+                    "name": "getStorageList",
+                    "output": {
+                        "deviceName": "str",
+                        "error": "str",
+                        "format": "str",
+                        "formattable": "str",
+                        "freeCapacityMB": "int",
+                        "isAvailable": "str",
+                        "lun": "int",
+                        "mounted": "str",
+                        "permission": "str",
+                        "position": "str",
+                        "protocol": "str",
+                        "systemAreaCapacityMB": "int",
+                        "type": "str",
+                        "uri": "str",
+                        "volumeLabel": "str",
+                        "wholeCapacityMB": "int"
+                    },
+                    "service": "system",
+                    "version": "1.2"
+                },
+                "getSupportedApplicationStatusList": {
+                    "input": null,
+                    "name": "getSupportedApplicationStatusList",
+                    "output": {
+                        "name": "str",
+                        "status": "str"
+                    },
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "getSystemInformation": {
+                    "input": null,
+                    "name": "getSystemInformation",
+                    "output": {
+                        "area": "str",
+                        "bdAddr": "str",
+                        "bleID": "str",
+                        "bluetoothSppRoleForAndroidApp": "str",
+                        "bluetoothSppRoleForIosApp": "str",
+                        "cid": "str",
+                        "deviceColor": "str",
+                        "deviceID": "str",
+                        "duid": "str",
+                        "esn": "str",
+                        "generation": "str",
+                        "helpUrl": "str",
+                        "iconUrl": "str",
+                        "initialPowerOnTime": "str",
+                        "isCustomInstall": "bool",
+                        "language": "str",
+                        "lastPowerOnTime": "str",
+                        "macAddr": "str",
+                        "model": "str",
+                        "name": "str",
+                        "product": "str",
+                        "region": "str",
+                        "serial": "str",
+                        "ssid": "str",
+                        "version": "str",
+                        "wirelessMacAddr": "str"
+                    },
+                    "service": "system",
+                    "version": "1.6"
+                },
+                "getSystemSupportedFeature": {
+                    "input": {
+                        "name": "str"
+                    },
+                    "name": "getSystemSupportedFeature",
+                    "output": {
+                        "name": "str",
+                        "supported": "bool",
+                        "value": "str"
+                    },
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "getVersions": {
+                    "input": null,
+                    "name": "getVersions",
+                    "output": "str",
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "getVoiceCommandGuide": {
+                    "input": {
+                        "service": "str"
+                    },
+                    "name": "getVoiceCommandGuide",
+                    "output": {
+                        "samples": "string*"
+                    },
+                    "service": "system",
+                    "version": "1.1"
+                },
+                "getWuTangInfo": {
+                    "input": {
+                        "target": "str"
+                    },
+                    "name": "getWuTangInfo",
+                    "output": {
+                        "candidate": "GeneralSettingsCandidate[]",
+                        "currentValue": "str",
+                        "deviceUIInfo": "str",
+                        "isAvailable": "bool",
+                        "target": "str",
+                        "title": "str",
+                        "titleTextID": "str",
+                        "type": "str"
+                    },
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "setAlexaRegistrationInfo": {
+                    "input": {
+                        "authorizationCode": "str",
+                        "clientID": "str",
+                        "encKey": "str",
+                        "redirectUri": "str",
+                        "timeZone": "str"
+                    },
+                    "name": "setAlexaRegistrationInfo",
+                    "output": null,
+                    "service": "system",
+                    "version": "1.1"
+                },
+                "setClientInfo": {
+                    "input": {
+                        "target": "str",
+                        "value": "str"
+                    },
+                    "name": "setClientInfo",
+                    "output": null,
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "setDeviceMiscSettings": {
+                    "input": {
+                        "settings": "GeneralSettings[]"
+                    },
+                    "name": "setDeviceMiscSettings",
+                    "output": null,
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "setPowerSettings": {
+                    "input": {
+                        "settings": "GeneralSettings[]"
+                    },
+                    "name": "setPowerSettings",
+                    "output": null,
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "setPowerStatus": {
+                    "input": {
+                        "standbyDetail": "str",
+                        "status": "str"
+                    },
+                    "name": "setPowerStatus",
+                    "output": null,
+                    "service": "system",
+                    "version": "1.1"
+                },
+                "setSleepTimerSettings": {
+                    "input": {
+                        "settings": "GeneralSettings[]"
+                    },
+                    "name": "setSleepTimerSettings",
+                    "output": null,
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "setWuTangInfo": {
+                    "input": {
+                        "settings": "GeneralSettings[]"
+                    },
+                    "name": "setWuTangInfo",
+                    "output": null,
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "switchNotifications": {
+                    "input": {
+                        "disabled": "ApiIdentity[]",
+                        "enabled": "ApiIdentity[]"
+                    },
+                    "name": "switchNotifications",
+                    "output": {
+                        "disabled": "ApiIdentity[]",
+                        "enabled": "ApiIdentity[]",
+                        "rejected": "ApiIdentity[]",
+                        "unsupported": "ApiIdentity[]"
+                    },
+                    "service": "system",
+                    "version": "1.0"
+                },
+                "unregistAlexaDevice": {
+                    "input": null,
+                    "name": "unregistAlexaDevice",
+                    "output": {
+                        "status": "str"
+                    },
+                    "service": "system",
+                    "version": "1.0"
+                }
+            },
+            "notifications": {
+                "notifyAlexaRegistrationStatus": {
+                    "name": "notifyAlexaRegistrationStatus",
+                    "version": "1.0"
+                },
+                "notifyPowerStatus": {
+                    "name": "notifyPowerStatus",
+                    "version": "1.0"
+                },
+                "notifySWUpdateInfo": {
+                    "name": "notifySWUpdateInfo",
+                    "version": "1.0"
+                },
+                "notifySettingsUpdate": {
+                    "name": "notifySettingsUpdate",
+                    "version": "1.1"
+                },
+                "notifyStorageStatus": {
+                    "name": "notifyStorageStatus",
+                    "version": "1.1"
+                }
+            },
+            "protocols": []
+        }
+    },
+    "sysinfo": {
+        "bdAddr": "38:7c:76:5d:d3:31",
+        "bleID": "48154266",
+        "bssid": null,
+        "generation": "",
+        "macAddr": "f8:4e:17:1f:4c:ba",
+        "model": "STR-AN1000",
+        "serialNumber": "3300540",
+        "ssid": null,
+        "version": "001.244",
+        "wirelessMacAddr": "38:7c:76:5d:d3:30"
+    }
+}

--- a/songpal/containers.py
+++ b/songpal/containers.py
@@ -124,7 +124,6 @@ class Content:
     isBrowsable = attr.ib()
     uri = attr.ib()
     contentKind = attr.ib()
-    kind = attr.ib()  # for newer devices
 
     isPlayable = attr.ib()
     index = attr.ib()
@@ -140,8 +139,7 @@ class Content:
     broadcastFreq = attr.ib()
 
     def __str__(self):
-        contentKind = self.contentKind if self.contentKind is not None else self.kind
-        return f"{self.title} ({self.uri}, kind: {contentKind})"
+        return f"{self.title} ({self.uri}, kind: {self.contentKind})"
 
 
 @attr.s
@@ -187,7 +185,6 @@ class PlayInfo:
 
     stateInfo = attr.ib(converter=_make)
     contentKind = attr.ib()
-    kind = attr.ib()  # for newer devices
     uri = attr.ib()
     output = attr.ib()
 

--- a/songpal/containers.py
+++ b/songpal/containers.py
@@ -80,29 +80,28 @@ class PlaybackFunction:
 
 
 @attr.s
-class AvailableFunctions:
+class PlaybackFunctions:
+    """Container for playback functions."""
+
+    make = classmethod(make)
+
+    def _convert_playback_functions(x) -> List[PlaybackFunction]:
+        return [PlaybackFunction.make(**y) for y in x]  # type: ignore
+
+    uri = attr.ib()
+    functions = attr.ib(converter=_convert_playback_functions)
+
+
+class AvailablePlaybackFunctions(PlaybackFunctions):
     """Container for available playback functions."""
 
-    make = classmethod(make)
 
-    def _convert_playback_functions(x) -> List[PlaybackFunction]:
-        return [PlaybackFunction.make(**y) for y in x]  # type: ignore
-
-    uri = attr.ib()
-    functions = attr.ib(converter=_convert_playback_functions)
-
-
-@attr.s
-class SupportedFunctions:
+class SupportedPlaybackFunctions(PlaybackFunctions):
     """Container for supported playback functions."""
 
-    make = classmethod(make)
 
-    def _convert_playback_functions(x) -> List[PlaybackFunction]:
-        return [PlaybackFunction.make(**y) for y in x]  # type: ignore
-
-    uri = attr.ib()
-    functions = attr.ib(converter=_convert_playback_functions)
+# Name change backwards compatibility
+SupportedFunctions = SupportedPlaybackFunctions
 
 
 @attr.s

--- a/songpal/containers.py
+++ b/songpal/containers.py
@@ -80,6 +80,19 @@ class PlaybackFunction:
 
 
 @attr.s
+class AvailableFunctions:
+    """Container for available playback functions."""
+
+    make = classmethod(make)
+
+    def _convert_playback_functions(x) -> List[PlaybackFunction]:
+        return [PlaybackFunction.make(**y) for y in x]  # type: ignore
+
+    uri = attr.ib()
+    functions = attr.ib(converter=_convert_playback_functions)
+
+
+@attr.s
 class SupportedFunctions:
     """Container for supported playback functions."""
 
@@ -111,6 +124,7 @@ class Content:
     isBrowsable = attr.ib()
     uri = attr.ib()
     contentKind = attr.ib()
+    kind = attr.ib()  # for newer devices
 
     isPlayable = attr.ib()
     index = attr.ib()
@@ -126,7 +140,8 @@ class Content:
     broadcastFreq = attr.ib()
 
     def __str__(self):
-        return f"{self.title} ({self.uri}, kind: {self.contentKind})"
+        contentKind = self.contentKind if self.contentKind is not None else self.kind
+        return f"{self.title} ({self.uri}, kind: {contentKind})"
 
 
 @attr.s
@@ -172,6 +187,7 @@ class PlayInfo:
 
     stateInfo = attr.ib(converter=_make)
     contentKind = attr.ib()
+    kind = attr.ib()  # for newer devices
     uri = attr.ib()
     output = attr.ib()
 

--- a/songpal/device.py
+++ b/songpal/device.py
@@ -130,7 +130,7 @@ class Device:
         """Return JSON formatted supported API."""
         return await self.create_post_request("getSupportedApiInfo")
 
-    async def get_supported_methods(self):
+    async def get_supported_methods(self, default_latest: bool = False):
         """Get information about supported methods.
 
         Calling this as the first thing before doing anything else is
@@ -158,6 +158,16 @@ class Device:
                     # self.logger.debug("%s > %s" % (service, api))
                     if self.debug > 1:
                         _LOGGER.debug("> %s" % api)
+                    if api.latest_supported_version is None:
+                        _LOGGER.debug(
+                            "No supported version for %s.%s, using %s",
+                            service.name,
+                            api.name,
+                            api.version,
+                        )
+                    else:
+                        if default_latest:
+                            api.use_version(api.latest_supported_version)
             return self.services
 
         return None
@@ -409,9 +419,7 @@ class Device:
                     "Scheme not supported in version 1.3, use get_inputs() instead"
                 )
             self.services["avContent"]["getSourceList"].use_version("1.3")
-            res = await self.services["avContent"]["getSourceList"](scheme=scheme)
-        else:
-            res = await self.services["avContent"]["getSourceList"](scheme=scheme)
+        res = await self.services["avContent"]["getSourceList"](scheme=scheme)
         return [Source.make(**x) for x in res]
 
     async def get_content_count(self, source: str):

--- a/songpal/device.py
+++ b/songpal/device.py
@@ -59,10 +59,10 @@ class Device:
         self.debug = debug
         endpoint = urlparse(endpoint)
         self.endpoint = endpoint.geturl()
-        _LOGGER.debug("Endpoint: %s" % self.endpoint)
+        _LOGGER.debug("Endpoint: %s", self.endpoint)
 
         self.guide_endpoint = endpoint._replace(path="/sony/guide").geturl()
-        _LOGGER.debug("Guide endpoint: %s" % self.guide_endpoint)
+        _LOGGER.debug("Guide endpoint: %s", self.guide_endpoint)
 
         if force_protocol:
             _LOGGER.warning("Forcing protocol %s", force_protocol)
@@ -103,7 +103,7 @@ class Device:
                     self.guide_endpoint, json=payload, headers=headers
                 )
                 if self.debug > 1:
-                    _LOGGER.debug(f"Received {res.status}: {res.text}")
+                    _LOGGER.debug("Received %s: %s", res.status, res.text)
                 if res.status != 200:
                     res_json = await res.json(content_type=None)
                     raise SongpalException(
@@ -140,7 +140,7 @@ class Device:
 
         if "result" in response:
             services = response["result"][0]
-            _LOGGER.debug("Got %s services!" % len(services))
+            _LOGGER.debug("Got %s services!", len(services))
 
             for x in services:
                 serv = await Service.from_payload(
@@ -157,7 +157,7 @@ class Device:
                 for api in service.methods:
                     # self.logger.debug("%s > %s" % (service, api))
                     if self.debug > 1:
-                        _LOGGER.debug("> %s" % api)
+                        _LOGGER.debug("> %s", api)
                     if api.latest_supported_version is None:
                         _LOGGER.debug(
                             "No supported version for %s.%s, using %s",
@@ -280,14 +280,7 @@ class Device:
 
     async def get_inputs(self) -> List[Input]:
         """Return list of available outputs."""
-        active_input_uri = ""
-        for z in await self.get_zones():
-            if z.active:
-                active_input_uri = (
-                    await self.get_available_playback_functions(output=z.uri)
-                )[0].uri
-                break
-
+        active_input_uri = (await self.get_available_playback_functions())[0].uri
         method = self.services["avContent"]["getCurrentExternalTerminalsStatus"]
         if method.supports_version("1.2"):
             method.use_version("1.2")
@@ -300,9 +293,9 @@ class Device:
             if ("title" in x and x["title"] != "") and "meta:zone:output" not in x[
                 "meta"
             ]:
-                input = Input.make(services=self.services, **x)
-                input.active = True if input.uri == active_input_uri else False
-                inputs.append(input)
+                input_ = Input.make(services=self.services, **x)
+                input_.active = True if input_.uri == active_input_uri else False
+                inputs.append(input_)
         return inputs
 
     async def get_zones(self) -> List[Zone]:

--- a/songpal/device.py
+++ b/songpal/device.py
@@ -130,7 +130,7 @@ class Device:
         """Return JSON formatted supported API."""
         return await self.create_post_request("getSupportedApiInfo")
 
-    async def get_supported_methods(self, default_latest: bool = False):
+    async def get_supported_methods(self, *, default_latest: bool = False):
         """Get information about supported methods.
 
         Calling this as the first thing before doing anything else is
@@ -288,22 +288,12 @@ class Device:
                 )[0].uri
                 break
 
-        if (
-            "1.2"
-            in self.services["avContent"][
-                "getCurrentExternalTerminalsStatus"
-            ].supported_versions
-        ):
-            self.services["avContent"]["getCurrentExternalTerminalsStatus"].use_version(
-                "1.2"
-            )
-            res = await self.services["avContent"]["getCurrentExternalTerminalsStatus"](
-                {}
-            )
+        method = self.services["avContent"]["getCurrentExternalTerminalsStatus"]
+        if method.supports_version("1.2"):
+            method.use_version("1.2")
+            res = await method({})
         else:
-            res = await self.services["avContent"][
-                "getCurrentExternalTerminalsStatus"
-            ]()
+            res = await method()
         inputs = []
         for x in res:
             # Hidden inputs (device settings) return with title=""
@@ -317,22 +307,12 @@ class Device:
 
     async def get_zones(self) -> List[Zone]:
         """Return list of available zones."""
-        if (
-            "1.2"
-            in self.services["avContent"][
-                "getCurrentExternalTerminalsStatus"
-            ].supported_versions
-        ):
-            self.services["avContent"]["getCurrentExternalTerminalsStatus"].use_version(
-                "1.2"
-            )
-            res = await self.services["avContent"]["getCurrentExternalTerminalsStatus"](
-                {}
-            )
+        method = self.services["avContent"]["getCurrentExternalTerminalsStatus"]
+        if method.supports_version("1.2"):
+            method.use_version("1.2")
+            res = await method({})
         else:
-            res = await self.services["avContent"][
-                "getCurrentExternalTerminalsStatus"
-            ]()
+            res = await method()
         zones = [
             Zone.make(services=self.services, **x)
             for x in res
@@ -413,13 +393,14 @@ class Device:
 
     async def get_source_list(self, scheme: str = "") -> List[Source]:
         """Return available sources for playback."""
-        if "1.3" in self.services["avContent"]["getSourceList"].supported_versions:
+        method = self.services["avContent"]["getSourceList"]
+        if method.supports_version("1.3"):
             if scheme == "extInput":
                 raise SongpalException(
                     "Scheme not supported in version 1.3, use get_inputs() instead"
                 )
-            self.services["avContent"]["getSourceList"].use_version("1.3")
-        res = await self.services["avContent"]["getSourceList"](scheme=scheme)
+            method.use_version("1.3")
+        res = await method(scheme=scheme)
         return [Source.make(**x) for x in res]
 
     async def get_content_count(self, source: str):

--- a/songpal/device.py
+++ b/songpal/device.py
@@ -391,7 +391,18 @@ class Device:
 
     async def get_source_list(self, scheme: str = "") -> List[Source]:
         """Return available sources for playback."""
-        res = await self.services["avContent"]["getSourceList"](scheme=scheme)
+        if await self.services["avContent"].is_method_version_supported(
+            "getSourceList", "1.3"
+        ):
+            if scheme == "extInput":
+                raise SongpalException(
+                    "Scheme not supported in version 1.3, use get_inputs() instead"
+                )
+            res = await self.services["avContent"]["getSourceList"](
+                scheme=scheme, version=1.3
+            )
+        else:
+            res = await self.services["avContent"]["getSourceList"](scheme=scheme)
         return [Source.make(**x) for x in res]
 
     async def get_content_count(self, source: str):

--- a/songpal/device.py
+++ b/songpal/device.py
@@ -278,8 +278,11 @@ class Device:
                 )[0].uri
                 break
 
-        if await self.services["avContent"].is_method_version_supported(
-            "getCurrentExternalTerminalsStatus", "1.2"
+        if (
+            "1.2"
+            in self.services["avContent"][
+                "getCurrentExternalTerminalsStatus"
+            ].supported_versions
         ):
             res = await self.services["avContent"]["getCurrentExternalTerminalsStatus"](
                 {}, version=1.2
@@ -301,8 +304,11 @@ class Device:
 
     async def get_zones(self) -> List[Zone]:
         """Return list of available zones."""
-        if await self.services["avContent"].is_method_version_supported(
-            "getCurrentExternalTerminalsStatus", "1.2"
+        if (
+            "1.2"
+            in self.services["avContent"][
+                "getCurrentExternalTerminalsStatus"
+            ].supported_versions
         ):
             res = await self.services["avContent"]["getCurrentExternalTerminalsStatus"](
                 {}, version=1.2
@@ -391,9 +397,7 @@ class Device:
 
     async def get_source_list(self, scheme: str = "") -> List[Source]:
         """Return available sources for playback."""
-        if await self.services["avContent"].is_method_version_supported(
-            "getSourceList", "1.3"
-        ):
+        if "1.3" in self.services["avContent"]["getSourceList"].supported_versions:
             if scheme == "extInput":
                 raise SongpalException(
                     "Scheme not supported in version 1.3, use get_inputs() instead"

--- a/songpal/device.py
+++ b/songpal/device.py
@@ -11,7 +11,7 @@ import aiohttp
 
 from songpal.common import SongpalException
 from songpal.containers import (
-    AvailableFunctions,
+    AvailablePlaybackFunctions,
     Content,
     ContentInfo,
     Input,
@@ -24,7 +24,7 @@ from songpal.containers import (
     SoftwareUpdateInfo,
     Source,
     Storage,
-    SupportedFunctions,
+    SupportedPlaybackFunctions,
     Sysinfo,
     Volume,
     Zone,
@@ -356,10 +356,10 @@ class Device:
 
     async def get_supported_playback_functions(
         self, uri=""
-    ) -> List[SupportedFunctions]:
+    ) -> List[SupportedPlaybackFunctions]:
         """Return list of inputs and their supported functions."""
         return [
-            SupportedFunctions.make(**x)
+            SupportedPlaybackFunctions.make(**x)
             for x in await self.services["avContent"]["getSupportedPlaybackFunction"](
                 uri=uri
             )
@@ -471,13 +471,13 @@ class Device:
 
     async def get_available_playback_functions(
         self, output=""
-    ) -> List[AvailableFunctions]:
+    ) -> List[AvailablePlaybackFunctions]:
         """Return available playback functions.
 
         If no output is given the current is assumed.
         """
         return [
-            AvailableFunctions.make(**x)
+            AvailablePlaybackFunctions.make(**x)
             for x in await self.services["avContent"]["getAvailablePlaybackFunction"](
                 output=output
             )

--- a/songpal/device.py
+++ b/songpal/device.py
@@ -316,9 +316,11 @@ class Device:
         params = {"settings": [{"target": target, "value": value}]}
         return await self.services["avContent"]["setBluetoothSettings"](params)
 
-    async def get_custom_eq(self):
+    async def get_custom_eq(self, target=""):
         """Get custom EQ settings."""
-        return await self.services["audio"]["getCustomEqualizerSettings"]({})
+        return await self.services["audio"]["getCustomEqualizerSettings"](
+            {"target": target}
+        )
 
     async def set_custom_eq(self, target: str, value: str) -> None:
         """Set custom EQ settings."""
@@ -421,9 +423,11 @@ class Device:
         params = {"settings": [{"target": target, "value": value}]}
         return await self.services["audio"]["setSoundSettings"](params)
 
-    async def get_speaker_settings(self) -> List[Setting]:
+    async def get_speaker_settings(self, target="") -> List[Setting]:
         """Return speaker settings."""
-        speaker_settings = await self.services["audio"]["getSpeakerSettings"]({})
+        speaker_settings = await self.services["audio"]["getSpeakerSettings"](
+            {"target": target}
+        )
         return [Setting.make(**x) for x in speaker_settings]
 
     async def set_speaker_settings(self, target: str, value: str):

--- a/songpal/device.py
+++ b/songpal/device.py
@@ -284,8 +284,11 @@ class Device:
                 "getCurrentExternalTerminalsStatus"
             ].supported_versions
         ):
+            self.services["avContent"]["getCurrentExternalTerminalsStatus"].use_version(
+                "1.2"
+            )
             res = await self.services["avContent"]["getCurrentExternalTerminalsStatus"](
-                {}, version=1.2
+                {}
             )
         else:
             res = await self.services["avContent"][
@@ -310,8 +313,11 @@ class Device:
                 "getCurrentExternalTerminalsStatus"
             ].supported_versions
         ):
+            self.services["avContent"]["getCurrentExternalTerminalsStatus"].use_version(
+                "1.2"
+            )
             res = await self.services["avContent"]["getCurrentExternalTerminalsStatus"](
-                {}, version=1.2
+                {}
             )
         else:
             res = await self.services["avContent"][
@@ -402,9 +408,8 @@ class Device:
                 raise SongpalException(
                     "Scheme not supported in version 1.3, use get_inputs() instead"
                 )
-            res = await self.services["avContent"]["getSourceList"](
-                scheme=scheme, version=1.3
-            )
+            self.services["avContent"]["getSourceList"].use_version("1.3")
+            res = await self.services["avContent"]["getSourceList"](scheme=scheme)
         else:
             res = await self.services["avContent"]["getSourceList"](scheme=scheme)
         return [Source.make(**x) for x in res]

--- a/songpal/device.py
+++ b/songpal/device.py
@@ -165,9 +165,8 @@ class Device:
                             api.name,
                             api.version,
                         )
-                    else:
-                        if default_latest:
-                            api.use_version(api.latest_supported_version)
+                    elif default_latest:
+                        api.use_version(api.latest_supported_version)
             return self.services
 
         return None
@@ -290,11 +289,9 @@ class Device:
         inputs = []
         for x in res:
             # Hidden inputs (device settings) return with title=""
-            if ("title" in x and x["title"] != "") and "meta:zone:output" not in x[
-                "meta"
-            ]:
+            if x.get("title") and "meta:zone:output" not in x["meta"]:
                 input_ = Input.make(services=self.services, **x)
-                input_.active = True if input_.uri == active_input_uri else False
+                input_.active = input_.uri == active_input_uri
                 inputs.append(input_)
         return inputs
 

--- a/songpal/main.py
+++ b/songpal/main.py
@@ -632,7 +632,7 @@ async def dump_devinfo(dev: Device, file):
     """
     import attr
 
-    methods = await dev.get_supported_methods()
+    methods = await dev.get_supported_methods(True)
     res = {
         "supported_methods": {k: v.asdict() for k, v in methods.items()},
         "settings": [attr.asdict(x) for x in await dev.get_settings()],

--- a/songpal/main.py
+++ b/songpal/main.py
@@ -632,7 +632,7 @@ async def dump_devinfo(dev: Device, file):
     """
     import attr
 
-    methods = await dev.get_supported_methods(True)
+    methods = await dev.get_supported_methods(default_latest=True)
     res = {
         "supported_methods": {k: v.asdict() for k, v in methods.items()},
         "settings": [attr.asdict(x) for x in await dev.get_settings()],

--- a/songpal/method.py
+++ b/songpal/method.py
@@ -2,7 +2,7 @@
 import json
 import logging
 from pprint import pformat as pf
-from typing import Dict, List, Union
+from typing import Dict, Set, Union
 
 import attr
 
@@ -95,7 +95,7 @@ class Method:
 
     def __init__(self, service, signature: MethodSignature, debug=0):
         """Construct a method."""
-        self._supported_versions: List[str] = []
+        self._supported_versions: Set[str] = set()
         self.signatures: Dict[str, MethodSignature] = {}
         self.name = signature.name
         self.service = service
@@ -183,7 +183,7 @@ class Method:
         return self.signatures[self._version]
 
     @property
-    def supported_versions(self) -> List[str]:
+    def supported_versions(self) -> Set[str]:
         """List of supported version numbers for this method."""
         return self._supported_versions
 
@@ -194,8 +194,11 @@ class Method:
 
     def add_supported_version(self, version: str):
         """Add a supported version number for this method."""
-        if version not in self._supported_versions:
-            self._supported_versions.append(version)
+        self._supported_versions.add(version)
+
+    def supports_version(self, version: str) -> bool:
+        """Is this method version supported."""
+        return True if (version in self._supported_versions) else False
 
     def use_version(self, version: str):
         """Specify method signature version to use."""

--- a/songpal/method.py
+++ b/songpal/method.py
@@ -95,7 +95,7 @@ class Method:
 
     def __init__(self, service, signature: MethodSignature, debug=0):
         """Construct a method."""
-        self._supported_versions = ["none"]
+        self._supported_versions: List[str] = []
         self.versions = {}
         self.name = signature.name
         self.service = service
@@ -160,7 +160,11 @@ class Method:
     @property
     def latest_supported_version(self) -> str:
         """Latest version supported by this method."""
-        return sorted(self._supported_versions, reverse=True)[0]
+        return (
+            sorted(self._supported_versions, reverse=True)[0]
+            if len(self._supported_versions) > 0
+            else None
+        )
 
     @property
     def supported_versions(self) -> List[str]:

--- a/songpal/method.py
+++ b/songpal/method.py
@@ -2,7 +2,7 @@
 import json
 import logging
 from pprint import pformat as pf
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 import attr
 
@@ -93,18 +93,18 @@ class Method:
     invoke the method.
     """
 
-    def __init__(
-        self, service, signature: MethodSignature, supported_versions, debug=0
-    ):
+    def __init__(self, service, signature: MethodSignature, debug=0):
         """Construct a method."""
-        self.supported_versions = supported_versions
+        self._supported_versions = ["none"]
         self.versions = {}
         self.name = signature.name
         self.service = service
         self.versions[signature.version] = MethodVersion(service, signature, debug)
 
         self.debug = debug
-        self.default_version = next(iter(self.versions.values())).version
+
+        # Maintain backwards compatibility
+        self._default_version = next(iter(self.versions.values())).version
 
     def asdict(self) -> Dict[str, Union[Dict, Union[str, Dict]]]:
         """Return a dictionary describing the method.
@@ -151,6 +151,26 @@ class Method:
             return True
 
         return res[0]
+
+    @property
+    def default_version(self) -> str:
+        """Version of the first Method signature"""
+        return self._default_version
+
+    @property
+    def latest_supported_version(self) -> str:
+        """Latest version supported by this method."""
+        return sorted(self._supported_versions, reverse=True)[0]
+
+    @property
+    def supported_versions(self) -> List[str]:
+        """List of supported version numbers for this method."""
+        return self._supported_versions
+
+    def supported_version(self, version: str):
+        """Add a supported version for this method."""
+        if version not in self._supported_versions:
+            self._supported_versions.append(version)
 
     def __repr__(self):
         return f"<Method {self.service.name}.{self.name}>"

--- a/songpal/method.py
+++ b/songpal/method.py
@@ -102,16 +102,14 @@ class Method:
         self.signatures[signature.version] = signature
 
         self.debug = debug
-
-        # Maintain backwards compatibility
-        self._version = next(iter(self.signatures.values())).version
+        self._version = signature.version
 
     def asdict(self) -> Dict[str, Union[Dict, Union[str, Dict]]]:
         """Return a dictionary describing the method.
 
         This can be used to dump the information into a JSON file.
         """
-        return {"service": self.service.name}
+        return {"service": self.service.name, **self.signature.serialize()}
 
     async def __call__(self, *args, **kwargs):
         """Call the method with given parameters.

--- a/songpal/method.py
+++ b/songpal/method.py
@@ -161,9 +161,7 @@ class Method:
     @property
     def latest_supported_version(self) -> Optional[str]:
         """Latest version supported by this method."""
-        return (
-            max(self._supported_versions) if len(self._supported_versions) > 0 else None
-        )
+        return max(self._supported_versions) if self._supported_versions else None
 
     @property
     def outputs(self) -> Dict[str, type]:
@@ -190,22 +188,7 @@ class Method:
 
     def use_version(self, version: str):
         """Specify method signature version to use."""
-        if self.supports_version(version):
-            if version in self.signatures:
-                self._version = version
-            else:
-                raise SongpalException(
-                    "Version %s of %s.%s is supported, but no signature is available"
-                    % (version, self.service.name, self.name)
-                )
-        else:
-            _LOGGER.error(
-                "Version %s of %s.%s is not supported, version %s will be used instead",
-                version,
-                self.service.name,
-                self.name,
-                self.version,
-            )
+        self._version = version
 
     def __repr__(self):
         return "<Method {}.{}({}) -> {} version {}>".format(

--- a/songpal/method.py
+++ b/songpal/method.py
@@ -202,7 +202,22 @@ class Method:
 
     def use_version(self, version: str):
         """Specify method signature version to use."""
-        self._version = version
+        if self.supports_version(version):
+            if version in self.signatures:
+                self._version = version
+            else:
+                raise SongpalException(
+                    "Version %s of %s.%s is supported, but no signature is available"
+                    % (version, self.service.name, self.name)
+                )
+        else:
+            _LOGGER.error(
+                "Version %s of %s.%s is not supported, version %s will be used instead",
+                version,
+                self.service.name,
+                self.name,
+                self.version,
+            )
 
     def __repr__(self):
         return "<Method {}.{}({}) -> {} version {}>".format(

--- a/songpal/notification.py
+++ b/songpal/notification.py
@@ -152,14 +152,16 @@ class ContentChange(ChangeNotification, PlayInfo):
 
     make = classmethod(make)
 
+    kind = attr.ib()  # for newer devices
+
+    def __attrs_post_init__(self):
+        if self.contentKind is None:
+            self.contentKind = self.kind
+
     @property
     def is_input(self):
         """Return if the change was related to input."""
-        return (
-            self.contentKind == "input"
-            if self.contentKind is not None
-            else self.kind == "input"
-        )
+        return self.contentKind == "input"
 
 
 @attr.s

--- a/songpal/notification.py
+++ b/songpal/notification.py
@@ -155,7 +155,11 @@ class ContentChange(ChangeNotification, PlayInfo):
     @property
     def is_input(self):
         """Return if the change was related to input."""
-        return self.contentKind == "input"
+        return (
+            self.contentKind == "input"
+            if self.contentKind is not None
+            else self.kind == "input"
+        )
 
 
 @attr.s

--- a/songpal/notification.py
+++ b/songpal/notification.py
@@ -152,7 +152,8 @@ class ContentChange(ChangeNotification, PlayInfo):
 
     make = classmethod(make)
 
-    kind = attr.ib()  # for newer devices
+    kind = attr.ib()
+    """Used by newer devices, continue to access via `contentKind`"""
 
     def __attrs_post_init__(self):
         if self.contentKind is None:

--- a/songpal/service.py
+++ b/songpal/service.py
@@ -170,11 +170,11 @@ class Service:
         # TODO check for type correctness
         # TODO note parameters are not always necessary, see getPlaybackModeSettings
         # which has 'target' and 'uri' but works just fine without anything (wildcard)
-        # if len(params) != len(method.signature.input):
-        #     _LOGGER.error(f"args: {args} signature: {method.signature.input}")
+        # if len(params) != len(method.inputs):
+        #     _LOGGER.error(f"args: {args} signature: {method.inputs}")
         #     raise Exception(
         #         "Invalid number of inputs, wanted %s got %s / %s"
-        #         % (len(method.signature.input), len(args), len(kwargs))
+        #         % (len(method.inputs), len(args), len(kwargs))
         #     )
 
         async with aiohttp.ClientSession() as session:

--- a/songpal/service.py
+++ b/songpal/service.py
@@ -84,7 +84,7 @@ class Service:
             raise SongpalException(
                 f"No known protocols for {service_name}, got: {protocols}"
             )
-        _LOGGER.debug("Using protocol: %s" % protocol)
+        _LOGGER.debug("Using protocol: %s", protocol)
 
         service_endpoint = f"{endpoint}/{service_name}"
 
@@ -125,7 +125,7 @@ class Service:
                 for notification in payload["notifications"]
             ]
             service.notifications = notifications
-            _LOGGER.debug("Got notifications: %s" % notifications)
+            _LOGGER.debug("Got notifications: %s", notifications)
 
         return service
 
@@ -137,7 +137,13 @@ class Service:
          The return values are JSON objects.
         Use :func:__call__: provides external API leveraging this.
         """
-        _LOGGER.debug(f"{method.name} got called with args ({args}) kwargs ({kwargs})")
+        _LOGGER.debug(
+            "%s version %s got called with args (%s) kwargs (%s)",
+            method.name,
+            method.version,
+            args,
+            kwargs,
+        )
 
         # Used for allowing keeping reading from the socket
         _consumer = None
@@ -301,7 +307,7 @@ class Service:
             _LOGGER.debug("No notifications available for %s", self.name)
 
     async def stop_listen_notifications(self):
-        _LOGGER.debug("Stop listening on %s" % self.name)
+        _LOGGER.debug("Stop listening on %s", self.name)
         self.listening = False
 
     def asdict(self):


### PR DESCRIPTION
I have a Sony STR-AN1000 which isn't fully supported. This PR adds support.

Updated to allow the support of multiple API method versions returned by `getMethodTypes`. It will also check if the version currently being used is a specifically supported version (`getSupportedApiInfo`) for the device and log a debug message if not.

Adds support for the following specific API Methods
- version `1.2` for `getCurrentExternalTerminalsStatus`. Includes what should be a non-breaking change for `notifyPlayingContentInfo` notification.
- version `1.3` for `getSourceList`.

Update method parameters for the following, as newer devices can be stricter with the API spec. Should be non-breaking.
- `getCustomEqualizerSettings`.
- `getSpeakerSettings`.

Limited backward compatibility testing has been done with a STR-DN1080.

Conversation can be found #130