### PR TITLE
Add defining source-address for discover

### DIFF
--- a/songpal/discovery.py
+++ b/songpal/discovery.py
@@ -23,7 +23,7 @@ class DiscoveredDevice:
 
 class Discover:
     @staticmethod
-    async def discover(timeout, debug=0, callback=None):
+    async def discover(timeout, debug=0, callback=None, source_address=None):
         """Discover supported devices."""
         ST = "urn:schemas-sony-com:service:ScalarWebAPI:1"
         _LOGGER.info("Discovering for %s seconds" % timeout)
@@ -75,6 +75,12 @@ class Discover:
             if callback is not None:
                 await callback(dev)
 
+        if source_address is not None:
+            source_address = (source_address, 0)
+
         await async_search(
-            timeout=timeout, search_target=ST, async_callback=parse_device
+            timeout=timeout,
+            search_target=ST,
+            async_callback=parse_device,
+            source=source_address,
         )

--- a/songpal/main.py
+++ b/songpal/main.py
@@ -180,8 +180,9 @@ async def status(dev: Device):
 
 @cli.command()
 @coro
+@click.option("--source-address", required=False)
 @click.pass_context
-async def discover(ctx):
+async def discover(ctx, source_address):
     """Discover supported devices."""
     TIMEOUT = 5
 
@@ -202,7 +203,12 @@ async def discover(ctx):
             click.echo("    - Service: %s" % serv)
 
     click.echo("Discovering for %s seconds" % TIMEOUT)
-    await Discover.discover(TIMEOUT, ctx.obj["debug"] or 0, callback=print_discovered)
+    await Discover.discover(
+        TIMEOUT,
+        ctx.obj["debug"] or 0,
+        callback=print_discovered,
+        source_address=source_address,
+    )
 
 
 @cli.command()


### PR DESCRIPTION
This makes it possible to discover devices on multihomed setups.
The cli's discover command now also accepts `--source-address <addr>`.