### PR TITLE
Configure to use CI as trusted publisher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: "actions/checkout@v3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/checkout@v3"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,13 +7,15 @@ jobs:
   build-n-publish:
     name: Build release packages
     runs-on: ubuntu-latest
+    permissions:  # for trusted publishing
+      id-token: write
 
     steps:
     - uses: actions/checkout@master
     - name: Setup python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.x"
 
     - name: Install pypa/build
       run: >-
@@ -30,6 +32,4 @@ jobs:
         --outdir dist/
         .
     - name: Publish release on pypi
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
* Trusted publisher CI setup, see [blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) and [docs.pypi.org/trusted-publishers/using-a-publisher](https://docs.pypi.org/trusted-publishers/using-a-publisher/)
* Also, adapt CI for new python releases and drop py37 support