### PR TITLE
Fix methods dict keyerror

### DIFF
--- a/songpal/device.py
+++ b/songpal/device.py
@@ -159,7 +159,7 @@ class Device:
                         _LOGGER.debug("> %s", api)
                     if api.latest_supported_version is None:
                         _LOGGER.debug(
-                            "No supported version for %s.%s, using %s",
+                            "No supported version specified for %s.%s, using %s",
                             service.name,
                             api.name,
                             api.version,

--- a/songpal/service.py
+++ b/songpal/service.py
@@ -113,7 +113,14 @@ class Service:
         # Populate supported versions for method if available
         for api in payload["apis"]:
             for v in api["versions"]:
-                methods[api["name"]].add_supported_version(v["version"])
+                if api["name"] in methods:
+                    methods[api["name"]].add_supported_version(v["version"])
+                else:
+                    _LOGGER.info(
+                        "No matching method %s for supported version %s.",
+                        api["name"],
+                        v["version"],
+                    )
 
         service.methods = methods
 


### PR DESCRIPTION
Fixes #152 

The easiest solution was to guard against key errors. I thought about handling this particular response typo, but other non casing could exist, so went with logging it out.

Waiting on extra info for #151