### PR TITLE
Python3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: "actions/checkout@v3"

--- a/songpal/main.py
+++ b/songpal/main.py
@@ -45,7 +45,8 @@ def coro(f):
     """
 
     def wrapper(*args, **kwargs):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         try:
             return loop.run_until_complete(f(*args, **kwargs))
         except KeyboardInterrupt:

--- a/songpal/main.py
+++ b/songpal/main.py
@@ -45,8 +45,11 @@ def coro(f):
     """
 
     def wrapper(*args, **kwargs):
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
         try:
             return loop.run_until_complete(f(*args, **kwargs))
         except KeyboardInterrupt:


### PR DESCRIPTION
In Python 3.14, asyncio. get_event_loop() now raises a RuntimeError when called from a thread without a running event loop. 